### PR TITLE
feat: add table row resizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
             </div>
 
             <div class="overflow-x-auto">
-                <table class="min-w-full border-collapse border-border-color">
+                <table class="min-w-full border-collapse border-border-color resizable-table">
                     <thead class="text-white">
                         <tr>
                             <th class="p-2 text-center text-sm font-semibold tracking-wider border border-border-color w-12">N°</th>


### PR DESCRIPTION
## Summary
- allow resizing table rows and columns by dragging
- mark main table as resizable and initialize resizing on load

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e82bad63c832cadfa6eea6892c27d