### PR TITLE
feat: add PDF support and formatted AI responses

### DIFF
--- a/index.html
+++ b/index.html
@@ -578,6 +578,7 @@
                     </select>
                 </label>
             </div>
+            <input id="pdf-upload" type="file" accept="application/pdf" class="w-full border rounded p-1" />
             <textarea id="ai-input" rows="2" class="w-full border rounded p-1" placeholder="Escribe tu mensaje..."></textarea>
             <div id="ai-status" class="text-sm text-gray-500 hidden">Pensando...</div>
         </div>
@@ -586,6 +587,7 @@
     <button id="open-ai-panel" class="fixed bottom-4 right-4 p-3 bg-indigo-600 text-white rounded-full shadow-lg" aria-label="Abrir asistente de IA">🤖</button>
 
     <div id="print-area" class="hidden"></div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 <script src="index.js" type="module"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow uploading PDFs and include their text in AI prompts
- style AI responses with distinctive colors and basic markdown

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f22a0d0d0832cbf8778c0f85eb17b