### PR TITLE
feat: add undo and redo toolbar buttons

### DIFF
--- a/index.js
+++ b/index.js
@@ -1783,7 +1783,9 @@ document.addEventListener('DOMContentLoaded', function () {
         editorToolbar.appendChild(createButton('Subrayado', '<u>U</u>', 'underline'));
         editorToolbar.appendChild(createButton('Tachado', '<s>S</s>', 'strikeThrough'));
         editorToolbar.appendChild(createButton('Superíndice', 'X²', 'superscript'));
-        
+        editorToolbar.appendChild(createButton('Deshacer', '↺', 'undo'));
+        editorToolbar.appendChild(createButton('Rehacer', '↻', 'redo'));
+
         const eraserSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-eraser w-5 h-5"><path d="m7 21-4.3-4.3c-1-1-1-2.5 0-3.4l9.6-9.6c1-1 2.5-1 3.4 0l5.6 5.6c1 1 1 2.5 0 3.4L13 21H7Z"/><path d="M22 21H7"/><path d="m5 12 5 5"/></svg>`;
         editorToolbar.appendChild(createButton('Borrar formato', eraserSVG, 'removeFormat'));
 


### PR DESCRIPTION
## Summary
- add undo and redo buttons to the editor toolbar
- collapse selection after undo/redo using existing utility

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68916497fff4832cbc339e77da596c90