### PR TITLE
feat: add cloud sync, search replace, and shortcut customization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+dist/

--- a/cloud-sync.js
+++ b/cloud-sync.js
@@ -1,0 +1,16 @@
+export function setupCloudIntegration() {
+  const btn = document.getElementById('cloud-sync-btn');
+  if (!btn) return;
+  btn.addEventListener('click', async () => {
+    const provider = prompt('Proveedor de nube (drive/dropbox):', 'drive');
+    if (!provider) return;
+    try {
+      const data = localStorage.getItem('temarioState') || '';
+      console.log(`Syncing with ${provider}`, data);
+      alert(`Sincronización con ${provider} completada (simulada).`);
+    } catch (err) {
+      console.error('Cloud sync failed', err);
+      alert('Fallo la sincronización.');
+    }
+  });
+}

--- a/index.html
+++ b/index.html
@@ -27,6 +27,23 @@
                 <input type="text" id="search-bar" placeholder="Buscar tema..." class="w-full p-2 border border-border-color bg-secondary rounded-lg focus:ring-2 focus:ring-sky-400 focus:border-sky-400">
             </div>
 
+            <div id="advanced-tools" class="mb-4 flex flex-wrap items-center gap-2">
+                <input type="text" id="search-term" placeholder="Buscar texto" class="p-2 border border-border-color rounded">
+                <input type="text" id="replace-term" placeholder="Reemplazar con" class="p-2 border border-border-color rounded">
+                <label class="flex items-center gap-1 text-sm"><input type="checkbox" id="search-regex">Regex</label>
+                <label class="flex items-center gap-1 text-sm"><input type="checkbox" id="search-case">Mayús</label>
+                <button id="search-replace-btn" class="px-3 py-2 bg-sky-600 text-white rounded">Reemplazar</button>
+                <button id="cloud-sync-btn" class="px-3 py-2 bg-purple-600 text-white rounded">Sync Nube</button>
+                <div id="shortcut-settings" class="flex items-center gap-1">
+                    <select id="shortcut-action" class="p-1 border rounded">
+                        <option value="search">Buscar</option>
+                        <option value="replace">Reemplazar</option>
+                    </select>
+                    <input type="text" id="shortcut-keys" placeholder="Ctrl+F" class="p-1 border rounded">
+                    <button id="save-shortcut-btn" class="px-2 py-1 bg-gray-600 text-white rounded">Guardar</button>
+                </div>
+            </div>
+
             <div class="flex flex-col md:flex-row flex-wrap items-center justify-between gap-4 my-4">
                  <button id="ask-ai-btn" class="w-full md:w-auto order-3 md:order-1 px-6 py-2 bg-indigo-600 text-white font-semibold rounded-lg shadow-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-opacity-75 flex items-center justify-center space-x-2">
                     <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path d="M10 2a.75.75 0 01.75.75v.518a3.75 3.75 0 013.232 4.025l-1.82 1.82a.75.75 0 101.06 1.06l1.82-1.82A5.25 5.25 0 0010.75 2.52V2.75A.75.75 0 0110 2zM3.483 4.49A5.23 5.23 0 002.5 7.25v.518a3.75 3.75 0 014.025-3.232l-1.82-1.82a.75.75 0 10-1.06 1.06l1.82 1.82zM10 18a.75.75 0 01-.75-.75v-.518a3.75 3.75 0 01-3.232-4.025l1.82-1.82a.75.75 0 10-1.06-1.06l-1.82 1.82A5.25 5.25 0 009.25 17.48v.77a.75.75 0 01.75.75zM16.517 15.51a5.23 5.23 0 00.983-2.76v-.518a3.75 3.75 0 01-4.025 3.232l1.82 1.82a.75.75 0 101.06-1.06l-1.82-1.82zM10 12a2 2 0 100-4 2 2 0 000 4z"/></svg>

--- a/index.js
+++ b/index.js
@@ -9,6 +9,9 @@ import { GoogleGenAI } from "@google/genai";
 // inline IndexedDB implementation and keeps the rest of the code unchanged.
 import db from './db.js';
 import { makeTableResizable } from './table-resize.js';
+import { setupAdvancedSearchReplace } from './search-replace.js';
+import { setupKeyboardShortcuts } from './shortcuts.js';
+import { setupCloudIntegration } from './cloud-sync.js';
 
 const pdfjsLib = typeof window !== 'undefined' ? window['pdfjsLib'] : null;
 if (pdfjsLib) {
@@ -3802,6 +3805,9 @@ document.addEventListener('DOMContentLoaded', function () {
         setupEventListeners();
         document.querySelectorAll('table.resizable-table').forEach(initTableResize);
         applyTheme(document.documentElement.dataset.theme || 'default');
+        setupAdvancedSearchReplace();
+        setupKeyboardShortcuts();
+        setupCloudIntegration();
     }
 
     init();

--- a/search-replace.js
+++ b/search-replace.js
@@ -1,0 +1,28 @@
+export function setupAdvancedSearchReplace() {
+  const searchInput = document.getElementById('search-term');
+  const replaceInput = document.getElementById('replace-term');
+  const regexCheck = document.getElementById('search-regex');
+  const caseCheck = document.getElementById('search-case');
+  const btn = document.getElementById('search-replace-btn');
+  if (!searchInput || !replaceInput || !regexCheck || !caseCheck || !btn) return;
+
+  const replaceText = (node, regex, replacement) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      node.textContent = node.textContent.replace(regex, replacement);
+    } else {
+      node.childNodes.forEach(child => replaceText(child, regex, replacement));
+    }
+  };
+
+  btn.addEventListener('click', () => {
+    const pattern = searchInput.value;
+    if (!pattern) return;
+    const replacement = replaceInput.value;
+    let flags = 'g';
+    if (!caseCheck.checked) flags += 'i';
+    const regex = regexCheck.checked
+      ? new RegExp(pattern, flags)
+      : new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), flags);
+    replaceText(document.body, regex, replacement);
+  });
+}

--- a/shortcuts.js
+++ b/shortcuts.js
@@ -1,0 +1,41 @@
+const defaultShortcuts = {
+  search: 'Control+f',
+  replace: 'Control+h'
+};
+
+export function setupKeyboardShortcuts() {
+  const stored = JSON.parse(localStorage.getItem('shortcuts') || '{}');
+  const shortcuts = { ...defaultShortcuts, ...stored };
+
+  document.addEventListener('keydown', e => {
+    const parts = [];
+    if (e.ctrlKey) parts.push('Control');
+    if (e.altKey) parts.push('Alt');
+    if (e.shiftKey) parts.push('Shift');
+    const key = e.key.length === 1 ? e.key.toLowerCase() : e.key;
+    if (!['Control','Shift','Alt'].includes(key)) parts.push(key);
+    const combo = parts.join('+');
+    if (combo === shortcuts.search) {
+      e.preventDefault();
+      document.getElementById('search-term')?.focus();
+    } else if (combo === shortcuts.replace) {
+      e.preventDefault();
+      document.getElementById('replace-term')?.focus();
+    }
+  });
+
+  const actionSelect = document.getElementById('shortcut-action');
+  const keysInput = document.getElementById('shortcut-keys');
+  const saveBtn = document.getElementById('save-shortcut-btn');
+  if (actionSelect && keysInput && saveBtn) {
+    saveBtn.addEventListener('click', () => {
+      const action = actionSelect.value;
+      const combo = keysInput.value.trim();
+      if (combo) {
+        shortcuts[action] = combo;
+        localStorage.setItem('shortcuts', JSON.stringify(shortcuts));
+        alert('Atajo guardado');
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add advanced search/replace panel with regex and case sensitivity
- allow custom keyboard shortcuts saved to localStorage
- add placeholder cloud sync button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68916b3c0fec832c8410f9a3e1aad1cf