### PR TITLE
feat: add status filters for progress

### DIFF
--- a/index.css
+++ b/index.css
@@ -64,6 +64,12 @@
 
 
         body { font-family: 'Inter', sans-serif; background-color: var(--bg-primary); color: var(--text-primary); }
+
+        .filter-btn.active {
+            box-shadow: 0 0 0 2px #0ea5e9, 0 0 0 4px var(--bg-secondary);
+            background-color: #0ea5e9;
+            color: #fff;
+        }
         
         .fillable-cell, .lectura-cell { cursor: pointer; user-select: none; transition: background-color 0.2s; position: relative; text-align: center; }
         .fillable-cell.filled { background-color: var(--filled-bg); }

--- a/index.html
+++ b/index.html
@@ -21,19 +21,20 @@
 
     <div class="max-w-7xl mx-auto bg-secondary rounded-xl shadow-lg overflow-hidden my-8">
         <div class="p-6 sm:p-8">
-            <h1 class="text-2xl sm:text-3xl font-bold text-primary mb-4 text-center">Temario para Examen Final de Medicina Interna</h1
+            <h1 class="text-2xl sm:text-3xl font-bold text-primary mb-4 text-center">Temario para Examen Final de Medicina Interna</h1>
             <div class="flex flex-col md:flex-row flex-wrap items-center justify-between gap-4 my-4">
-                 <button id="ask-ai-btn" class="w-full md:w-auto order-3 md:order-1 px-6 py-2 bg-indigo-600 text-white font-semibold rounded-lg shadow-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-opacity-75 flex items-center justify-center space-x-2">
+                 <button id="ask-ai-btn" class="w-full md:w-auto order-1 px-6 py-2 bg-indigo-600 text-white font-semibold rounded-lg shadow-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-opacity-75 flex items-center justify-center space-x-2">
                     <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path d="M10 2a.75.75 0 01.75.75v.518a3.75 3.75 0 013.232 4.025l-1.82 1.82a.75.75 0 101.06 1.06l1.82-1.82A5.25 5.25 0 0010.75 2.52V2.75A.75.75 0 0110 2zM3.483 4.49A5.23 5.23 0 002.5 7.25v.518a3.75 3.75 0 014.025-3.232l-1.82-1.82a.75.75 0 10-1.06 1.06l1.82 1.82zM10 18a.75.75 0 01-.75-.75v-.518a3.75 3.75 0 01-3.232-4.025l1.82-1.82a.75.75 0 10-1.06-1.06l-1.82 1.82A5.25 5.25 0 009.25 17.48v.77a.75.75 0 01.75.75zM16.517 15.51a5.23 5.23 0 00.983-2.76v-.518a3.75 3.75 0 01-4.025 3.232l1.82 1.82a.75.75 0 101.06-1.06l-1.82-1.82zM10 12a2 2 0 100-4 2 2 0 000 4z"/></svg>
                     <span>Preguntar a la IA</span>
                 </button>
-                <div id="confidence-filters" class="order-1 md:order-2 flex items-center space-x-1 bg-gray-200 dark:bg-gray-700 rounded-lg p-1">
-                    <button data-filter="all" class="filter-btn active px-3 py-1 rounded-md text-sm font-medium">Todos</button>
-                    <button data-filter="1" class="filter-btn p-1.5 rounded-md" title="Confianza alta"><span class="w-4 h-4 rounded-full bg-green-400 border-2 border-green-600 inline-block"></span></button>
-                    <button data-filter="2" class="filter-btn p-1.5 rounded-md" title="Confianza media"><span class="w-4 h-4 rounded-full bg-yellow-400 border-2 border-yellow-600 inline-block"></span></button>
-                    <button data-filter="3" class="filter-btn p-1.5 rounded-md" title="Confianza baja"><span class="w-4 h-4 rounded-full bg-red-400 border-2 border-red-600 inline-block"></span></button>
+                <div id="status-filters" class="order-2 flex items-center space-x-1 bg-gray-200 dark:bg-gray-700 rounded-lg p-1">
+                    <span class="mr-2">Filtrar por estado de avance</span>
+                    <button data-filter="all" class="filter-btn active px-3 py-1 rounded-md text-sm font-medium" aria-label="Todos">Todos</button>
+                    <button data-filter="1" class="filter-btn p-1.5 rounded-md" title="Completo" aria-label="Completo"><span class="w-4 h-4 rounded-full bg-green-400 border-2 border-green-600 inline-block"></span></button>
+                    <button data-filter="2" class="filter-btn p-1.5 rounded-md" title="En progreso" aria-label="En progreso"><span class="w-4 h-4 rounded-full bg-yellow-400 border-2 border-yellow-600 inline-block"></span></button>
+                    <button data-filter="3" class="filter-btn p-1.5 rounded-md" title="Pendiente" aria-label="Pendiente"><span class="w-4 h-4 rounded-full bg-red-400 border-2 border-red-600 inline-block"></span></button>
                 </div>
-                <div class="order-2 md:order-3 flex items-center gap-2">
+                <div class="order-3 flex items-center gap-2">
                     <button id="export-btn" class="px-3 py-2 bg-green-600 text-white font-semibold rounded-lg shadow-md hover:bg-green-700 flex items-center" title="Exportar Progreso">
                         <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" /></svg>
                     </button>

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const importNoteFileInput = getElem('import-note-file-input');
     const settingsBtn = getElem('settings-btn');
     const settingsDropdown = getElem('settings-dropdown');
-    const confidenceFiltersContainer = getElem('confidence-filters');
+    const statusFiltersContainer = getElem('status-filters');
     const saveConfirmation = getElem('save-confirmation');
     const toggleReadOnlyBtn = getElem('toggle-readonly-btn');
     const toggleAllSectionsBtn = getElem('toggle-all-sections-btn');
@@ -779,7 +779,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     // --- State Variables ---
-    let activeConfidenceFilter = 'all';
+    let activeStatusFilter = 'all';
     let activeNoteIcon = null;
     let selectedImageForResize = null;
     let saveTimeout;
@@ -2444,7 +2444,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     function filterTable() {
-        const isFiltering = activeConfidenceFilter !== 'all';
+        const isFiltering = activeStatusFilter !== 'all';
 
         document.querySelectorAll('.section-header-row').forEach(headerRow => {
             const sectionName = headerRow.dataset.sectionHeader;
@@ -2455,9 +2455,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
             document.querySelectorAll(`tr[data-section="${sectionName}"]`).forEach(row => {
                 const confidence = row.querySelector('.confidence-dot')?.dataset.confidenceLevel || '0';
-                const matchesConfidence = activeConfidenceFilter === 'all' || confidence === activeConfidenceFilter;
+                const matchesStatus = activeStatusFilter === 'all' || confidence === activeStatusFilter;
 
-                if (matchesConfidence) {
+                if (matchesStatus) {
                     hasVisibleChildren = true;
                     row.style.display = isCollapsed ? 'none' : '';
                 } else {
@@ -3116,13 +3116,13 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         });
 
-        // Filter by confidence level
-        confidenceFiltersContainer.addEventListener('click', e => {
+        // Filter by status
+        statusFiltersContainer.addEventListener('click', e => {
             const filterBtn = e.target.closest('.filter-btn');
             if (filterBtn) {
-                confidenceFiltersContainer.querySelector('.active')?.classList.remove('active', 'bg-sky-500', 'text-white', 'dark:bg-sky-500');
-                filterBtn.classList.add('active', 'bg-sky-500', 'text-white', 'dark:bg-sky-500');
-                activeConfidenceFilter = filterBtn.dataset.filter;
+                statusFiltersContainer.querySelector('.active')?.classList.remove('active', 'ring-2', 'ring-offset-2', 'ring-sky-500', 'bg-sky-500', 'text-white', 'dark:bg-sky-500');
+                filterBtn.classList.add('active', 'ring-2', 'ring-offset-2', 'ring-sky-500', 'bg-sky-500', 'text-white', 'dark:bg-sky-500');
+                activeStatusFilter = filterBtn.dataset.filter;
                 filterTable();
             }
         });


### PR DESCRIPTION
## Summary
- rename confidence filter container to `status-filters` and add status labels
- highlight active filter with ring styling and updated JS references
- add CSS rule for `.filter-btn.active` to boost contrast

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68919f888a3c832cb9ac53ff8fab884d