### PR TITLE
Limit topic column width and truncate long text

### DIFF
--- a/index.css
+++ b/index.css
@@ -98,6 +98,15 @@
         .grand-total-row td { font-size: 0.75rem; }
         
         thead th { position: sticky; top: 0; z-index: 20; background-color: var(--header-bg); color: var(--header-text); }
+
+        .topic-column,
+        tbody td:nth-child(2) {
+            max-width: 18rem;
+            width: 25%;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+        }
         
         .modal-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.5); display: flex; align-items: center; justify-content: center; z-index: 1000; opacity: 0; visibility: hidden; transition: opacity 0.3s ease, visibility 0.3s ease; }
         .modal-overlay.visible { opacity: 1; visibility: visible; }

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
                     <thead class="text-white">
                         <tr>
                             <th class="p-2 text-center text-sm font-semibold tracking-wider border border-border-color w-12">N°</th>
-                            <th class="p-2 text-left text-sm font-semibold tracking-wider border border-border-color">Tema</th>
+                            <th class="topic-column p-2 text-left text-sm font-semibold tracking-wider border border-border-color">Tema</th>
                             <th class="p-2 text-center text-sm font-semibold tracking-wider border border-border-color w-40" contenteditable="true">Referencias</th>
                             <th class="p-2 text-center text-sm font-semibold tracking-wider border border-border-color w-40" contenteditable="true">Lectura</th>
                         </tr>


### PR DESCRIPTION
## Summary
- Add `topic-column` class to Tema header
- Restrict topic column width and truncate overflowed text for header and body

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68926e3aa9ec832c8f46f0b9844c5b2c