### PR TITLE
feat: export notes as html and indexed pdf

### DIFF
--- a/index.css
+++ b/index.css
@@ -107,12 +107,12 @@
         
         .notes-modal-content { max-width: 900px; height: 95vh; max-height: 95vh; padding: 0; }
         
-        .note-icon, .link-anchor, .edit-link-icon, .print-section-btn { display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: 50%; transition: background-color 0.2s, color 0.2s, opacity 0.2s, filter 0.2s; cursor: pointer; }
-        .note-icon:hover, .link-anchor:hover, .edit-link-icon:hover, .print-section-btn:hover { background-color: rgba(0,0,0,0.1); }
+        .note-icon, .link-anchor, .edit-link-icon, .print-section-btn, .export-section-btn { display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: 50%; transition: background-color 0.2s, color 0.2s, opacity 0.2s, filter 0.2s; cursor: pointer; }
+        .note-icon:hover, .link-anchor:hover, .edit-link-icon:hover, .print-section-btn:hover, .export-section-btn:hover { background-color: rgba(0,0,0,0.1); }
         
         .link-icon { width: 1.1em; height: 1.1em; }
-        .note-icon svg, .print-section-btn { width: 1.1em; height: 1.1em; }
-        .note-icon.section-note-icon, .print-section-btn { color: var(--section-header-text); opacity: 0.8; }
+        .note-icon svg, .print-section-btn, .export-section-btn { width: 1.1em; height: 1.1em; }
+        .note-icon.section-note-icon, .print-section-btn, .export-section-btn { color: var(--section-header-text); opacity: 0.8; }
         
         .note-icon.has-note {
             background-color: var(--btn-primary-bg);

--- a/index.js
+++ b/index.js
@@ -1985,6 +1985,12 @@ document.addEventListener('DOMContentLoaded', function () {
              window.print();
         });
         editorToolbar.appendChild(printBtn);
+
+        const printAllBtn = createButton('Imprimir todas las notas en PDF con índice', '🖨️', null, null, handlePrintAllWithIndex);
+        editorToolbar.appendChild(printAllBtn);
+
+        const exportAllBtn = createButton('Exportar todas las notas como HTML', '🌐', null, null, handleExportAllHTML);
+        editorToolbar.appendChild(exportAllBtn);
     }
 
     function openAiToolsModal() {
@@ -2998,6 +3004,133 @@ document.addEventListener('DOMContentLoaded', function () {
         window.print();
     }
 
+    async function handlePrintAllWithIndex() {
+        const topicRows = document.querySelectorAll('tr[data-topic-id]');
+        const printArea = getElem('print-area');
+        printArea.innerHTML = '';
+
+        const tocList = document.createElement('ol');
+        const contentWrapper = document.createElement('div');
+
+        for (const row of topicRows) {
+            const topicId = row.dataset.topicId;
+            const title = row.cells[1]?.textContent.trim();
+            const topicData = await db.get('topics', topicId);
+
+            if (topicData && topicData.notes && topicData.notes.length > 0) {
+                const anchorId = `topic-${topicId}`;
+                const li = document.createElement('li');
+                li.innerHTML = `<a href="#${anchorId}">${title}</a>`;
+                tocList.appendChild(li);
+
+                const topicDiv = document.createElement('div');
+                topicDiv.id = anchorId;
+                topicDiv.className = 'topic-print-wrapper';
+
+                const titleEl = document.createElement('h2');
+                titleEl.textContent = title;
+                topicDiv.appendChild(titleEl);
+
+                topicData.notes.forEach(note => {
+                    const noteDiv = document.createElement('div');
+                    noteDiv.innerHTML = note.content;
+                    noteDiv.querySelectorAll('a.subnote-link, a.postit-link, a.gallery-link').forEach(link => {
+                        link.outerHTML = `<span>${link.innerHTML}</span>`;
+                    });
+                    topicDiv.appendChild(noteDiv);
+                });
+
+                contentWrapper.appendChild(topicDiv);
+            }
+        }
+
+        if (!tocList.childElementCount) {
+            await showAlert("No hay notas para imprimir.");
+            return;
+        }
+
+        const tocContainer = document.createElement('div');
+        tocContainer.innerHTML = '<h2>Índice</h2>';
+        tocContainer.appendChild(tocList);
+        printArea.appendChild(tocContainer);
+        printArea.appendChild(contentWrapper);
+        window.print();
+    }
+
+    async function exportTopicsToHTML(filename, docTitle, topicRows) {
+        const topics = [];
+        for (const row of topicRows) {
+            const topicId = row.dataset.topicId;
+            const title = row.cells[1]?.textContent.trim();
+            const topicData = await db.get('topics', topicId);
+            if (topicData && topicData.notes && topicData.notes.length > 0) {
+                const parts = [];
+                topicData.notes.forEach(note => {
+                    const noteDiv = document.createElement('div');
+                    noteDiv.innerHTML = note.content;
+                    noteDiv.querySelectorAll('a.subnote-link, a.postit-link, a.gallery-link').forEach(link => {
+                        link.outerHTML = `<span>${link.innerHTML}</span>`;
+                    });
+                    parts.push(noteDiv.innerHTML);
+                });
+                topics.push({ id: `topic-${topicId}`, title, content: parts.join('') });
+            }
+        }
+
+        if (topics.length === 0) {
+            await showAlert('No hay notas para exportar.');
+            return;
+        }
+
+        const navItems = topics.map(t => `<li><a href="#${t.id}">${t.title}</a></li>`).join('');
+        const sectionsHTML = topics.map(t => `<section id="${t.id}"><h2>${t.title}</h2>${t.content}</section>`).join('');
+
+        const html = `<!DOCTYPE html><html lang="es"><head><meta charset="UTF-8"/><title>${docTitle}</title><style>
+body{margin:0;display:flex;font-family:sans-serif;}
+#sidebar{width:250px;background:#f5f5f5;padding:1em;overflow-y:auto;transition:transform .3s;}
+#sidebar.hidden{transform:translateX(-250px);}
+#content{flex:1;padding:1em;}
+#toggleSidebar{position:fixed;top:10px;left:10px;z-index:1000;}
+nav ul{list-style:none;padding:0;}
+nav a{text-decoration:none;color:#000;}
+</style></head><body><nav id="sidebar"><h2>${docTitle}</h2><ul>${navItems}</ul></nav><div id="content">${sectionsHTML}</div><button id="toggleSidebar">☰</button><script>
+document.getElementById('toggleSidebar').addEventListener('click',function(){document.getElementById('sidebar').classList.toggle('hidden');});
+</script></body></html>`;
+
+        const blob = new Blob([html], { type: 'text/html' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        a.click();
+        URL.revokeObjectURL(url);
+    }
+
+    async function handleExportSectionHTML(sectionHeaderRow) {
+        const sectionId = sectionHeaderRow.dataset.sectionHeader;
+        const sectionTitle = sectionHeaderRow.querySelector('.section-title').textContent.trim();
+        const topicRows = document.querySelectorAll(`tr[data-section="${sectionId}"]`);
+        await exportTopicsToHTML(`${sectionId}.html`, sectionTitle, topicRows);
+    }
+
+    async function handleExportAllHTML() {
+        const topicRows = document.querySelectorAll('tr[data-topic-id]');
+        await exportTopicsToHTML('todas-las-notas.html', 'Todas las notas', topicRows);
+    }
+
+    function addSectionExportButtons() {
+        document.querySelectorAll('.section-header-row').forEach(row => {
+            const printBtn = row.querySelector('.print-section-btn');
+            if (printBtn && !row.querySelector('.export-section-btn')) {
+                const exportBtn = document.createElement('button');
+                exportBtn.className = 'export-section-btn toolbar-btn no-print';
+                exportBtn.title = 'Guardar sección como HTML';
+                exportBtn.textContent = '🌐';
+                printBtn.insertAdjacentElement('afterend', exportBtn);
+            }
+        });
+    }
+
 
     // --- Event Listeners Setup ---
     function setupEventListeners() {
@@ -3113,6 +3246,16 @@ document.addEventListener('DOMContentLoaded', function () {
                 e.stopPropagation();
                 const sectionHeaderRow = printBtn.closest('.section-header-row');
                 handlePrintSection(sectionHeaderRow);
+            }
+        });
+
+        // Section export button
+        tableBody.addEventListener('click', (e) => {
+            const exportBtn = e.target.closest('.export-section-btn');
+            if (exportBtn) {
+                e.stopPropagation();
+                const sectionHeaderRow = exportBtn.closest('.section-header-row');
+                handleExportSectionHTML(sectionHeaderRow);
             }
         });
 
@@ -3787,6 +3930,7 @@ document.addEventListener('DOMContentLoaded', function () {
         setupEditorToolbar();
         populateIconPicker();
         loadState();
+        addSectionExportButtons();
         setupEventListeners();
         document.querySelectorAll('table.resizable-table').forEach(initTableResize);
         applyTheme(document.documentElement.dataset.theme || 'default');


### PR DESCRIPTION
## Summary
- add toolbar actions to print all notes with hyperlinked index and export them as HTML
- allow exporting individual sections to HTML with collapsible sidebar
- style new export buttons alongside existing controls

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6892b0519f1c832cb090eeea00183c9f