### PR TITLE
feat: add HTML and PDF export options

### DIFF
--- a/index.css
+++ b/index.css
@@ -107,12 +107,12 @@
         
         .notes-modal-content { max-width: 900px; height: 95vh; max-height: 95vh; padding: 0; }
         
-        .note-icon, .link-anchor, .edit-link-icon, .print-section-btn { display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: 50%; transition: background-color 0.2s, color 0.2s, opacity 0.2s, filter 0.2s; cursor: pointer; }
-        .note-icon:hover, .link-anchor:hover, .edit-link-icon:hover, .print-section-btn:hover { background-color: rgba(0,0,0,0.1); }
-        
+        .note-icon, .link-anchor, .edit-link-icon, .print-section-btn, .export-section-btn { display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: 50%; transition: background-color 0.2s, color 0.2s, opacity 0.2s, filter 0.2s; cursor: pointer; }
+        .note-icon:hover, .link-anchor:hover, .edit-link-icon:hover, .print-section-btn:hover, .export-section-btn:hover { background-color: rgba(0,0,0,0.1); }
+
         .link-icon { width: 1.1em; height: 1.1em; }
-        .note-icon svg, .print-section-btn { width: 1.1em; height: 1.1em; }
-        .note-icon.section-note-icon, .print-section-btn { color: var(--section-header-text); opacity: 0.8; }
+        .note-icon svg, .print-section-btn, .export-section-btn { width: 1.1em; height: 1.1em; }
+        .note-icon.section-note-icon, .print-section-btn, .export-section-btn { color: var(--section-header-text); opacity: 0.8; }
         
         .note-icon.has-note {
             background-color: var(--btn-primary-bg);

--- a/index.html
+++ b/index.html
@@ -41,6 +41,12 @@
                     <button id="import-btn" class="px-3 py-2 bg-sky-600 text-white font-semibold rounded-lg shadow-md hover:bg-sky-700 flex items-center" title="Importar desde archivo" aria-label="Importar desde archivo">
                         <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v3.75A2.25 2.25 0 0117.25 20.25H6.75A2.25 2.25 0 014.5 17.25V6.75A2.25 2.25 0 016.75 4.5H12l4.5 4.5v2.25" /><path stroke-linecap="round" stroke-linejoin="round" d="M9 9l3-3 3 3m-3-3v10.5" /></svg>
                     </button>
+                    <button id="print-all-notes-btn" class="px-3 py-2 bg-purple-600 text-white font-semibold rounded-lg shadow-md hover:bg-purple-700 flex items-center" title="Imprimir todas las notas (PDF)" aria-label="Imprimir todas las notas (PDF)">
+                        🖨️
+                    </button>
+                    <button id="export-all-html-btn" class="px-3 py-2 bg-emerald-600 text-white font-semibold rounded-lg shadow-md hover:bg-emerald-700 flex items-center" title="Exportar todas las notas a HTML" aria-label="Exportar todas las notas a HTML">
+                        🌐
+                    </button>
                     <input type="file" id="import-file-input" accept=".json" class="hidden">
                     <div class="h-6 border-l mx-2"></div>
                     <div class="relative">


### PR DESCRIPTION
## Summary
- add global buttons to export notes as HTML or print them to PDF
- enable per-section HTML export with side navigation
- style and register export controls

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892b3117734832c80e846a5ef07b7ff