### PR TITLE
feat: add pdf export with index

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,9 @@
                     <button id="export-btn" class="px-3 py-2 bg-green-600 text-white font-semibold rounded-lg shadow-md hover:bg-green-700 flex items-center" title="Exportar todo" aria-label="Exportar todo">
                         <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v3.75A2.25 2.25 0 0117.25 20.25H6.75A2.25 2.25 0 014.5 17.25V6.75A2.25 2.25 0 016.75 4.5H12l4.5 4.5v2.25" /><path stroke-linecap="round" stroke-linejoin="round" d="M9 15l3 3 3-3m-3 3V10.5" /></svg>
                     </button>
+                    <button id="export-pdf-btn" class="px-3 py-2 bg-red-600 text-white font-semibold rounded-lg shadow-md hover:bg-red-700 flex items-center" title="Exportar PDF" aria-label="Exportar PDF">
+                        <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v3.75A2.25 2.25 0 0117.25 20.25H6.75A2.25 2.25 0 014.5 17.25V6.75A2.25 2.25 0 016.75 4.5H12l4.5 4.5v2.25" /><path stroke-linecap="round" stroke-linejoin="round" d="M15 17.25l-3 3m0 0l-3-3m3 3V10.5" /></svg>
+                    </button>
                     <button id="import-btn" class="px-3 py-2 bg-sky-600 text-white font-semibold rounded-lg shadow-md hover:bg-sky-700 flex items-center" title="Importar desde archivo" aria-label="Importar desde archivo">
                         <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v3.75A2.25 2.25 0 0117.25 20.25H6.75A2.25 2.25 0 014.5 17.25V6.75A2.25 2.25 0 016.75 4.5H12l4.5 4.5v2.25" /><path stroke-linecap="round" stroke-linejoin="round" d="M9 9l3-3 3 3m-3-3v10.5" /></svg>
                     </button>
@@ -589,6 +592,7 @@
 
     <div id="print-area" class="hidden"></div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 <script src="index.js" type="module"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add toolbar button to export all topics as a PDF
- build PDF with title page, table of contents and back-to-index links

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892cb8c5360832cb2404514dfab9f29