### PR TITLE
Compact topic list display

### DIFF
--- a/index.css
+++ b/index.css
@@ -329,6 +329,9 @@
 table.resizable-table td,
 table.resizable-table th {
     position: relative;
+    padding: 0.25rem 0.25rem;
+    font-size: 0.75rem;
+    line-height: 1.1;
 }
 
 /* Floating image styles */


### PR DESCRIPTION
## Summary
- Reduce padding and font size for table headers and cells so more topics fit on screen

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68951aa2f070832caa4c2511fbefa4a6