### PR TITLE
Compacta la lista de temas en la ventana principal

### DIFF
--- a/index.css
+++ b/index.css
@@ -196,7 +196,15 @@
             color: var(--btn-primary-bg);
         }
         
-        .progress-ring-circle { transition: stroke-dashoffset 0.5s ease-out; }
+.progress-ring-circle { transition: stroke-dashoffset 0.5s ease-out; }
+
+/* Compact table styling for denser topic list */
+.compact-table th,
+.compact-table td {
+    padding: 0.125rem 0.25rem !important;
+    font-size: 0.75rem;
+    line-height: 1.25;
+}
         
         #icon-picker-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(40px, 1fr)); gap: 1rem; max-height: 300px; overflow-y: auto; padding: 1rem 0; }
         .icon-picker-item { cursor: pointer; padding: 8px; border-radius: 8px; transition: background-color 0.2s; }

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
             </div>
 
             <div class="overflow-x-auto">
-                <table class="min-w-full border-collapse border-border-color resizable-table">
+                <table class="min-w-full border-collapse border-border-color resizable-table compact-table">
                     <thead class="text-white">
                         <tr>
                             <th class="p-2 text-center text-sm font-semibold tracking-wider border border-border-color w-12">N°</th>


### PR DESCRIPTION
## Resumen
- Reduce el tamaño de la tabla de temas para mostrar más información en pantalla.
- Aplica reglas CSS para disminuir padding y tipografía de las celdas.

## Pruebas
- `npm test` *(falla: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68951aa2f070832caa4c2511fbefa4a6