### PR TITLE
feat: add draggable float image tool

### DIFF
--- a/index.css
+++ b/index.css
@@ -336,19 +336,22 @@ table.resizable-table th {
     display: block;
     max-width: 250px;
     margin: 0 1rem 1rem 0;
-    cursor: default;
+    cursor: move;
 }
 .float-image.float-left {
     float: left;
+    margin: 0 1rem 1rem 0;
 }
 .float-image.float-right {
     float: right;
+    margin: 0 0 1rem 1rem;
 }
 .float-image img {
     width: 100%;
     height: auto;
     display: block;
     border-radius: 0.25rem;
+    cursor: move;
 }
 
 /* Table size selection grid */

--- a/index.html
+++ b/index.html
@@ -358,6 +358,7 @@
                                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-upload w-5 h-5"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" x2="12" y1="3" y2="15"/></svg>
                             </button>
                             <input type="file" id="import-note-file-input" class="hidden" accept=".html,.txt">
+                            <input type="file" id="float-image-input" class="hidden" accept="image/*">
                             <button id="export-note-btn" class="toolbar-btn" title="Exportar a HTML">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-download w-5 h-5"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
                             </button>


### PR DESCRIPTION
## Summary
- add hidden file input and toolbar button to insert floating images
- enable drag-and-drop positioning for images with automatic text flow
- ensure floating images keep margins and re-enable dragging when notes load

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68953ae014d0832ca28e74e8d181552a