### PR TITLE
fix: show special character dropdown outside editor

### DIFF
--- a/index.css
+++ b/index.css
@@ -278,7 +278,7 @@
         .color-submenu.visible { display: grid; }
 
         .symbol-dropdown { position: relative; display: inline-block; }
-        .symbol-dropdown-content { display: none; position: absolute; right: 0; background-color: var(--bg-secondary); min-width: 280px; max-height: 200px; overflow-y: auto; box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2); z-index: 10; border-radius: 8px; border: 1px solid var(--border-color); padding: 8px; grid-template-columns: repeat(auto-fill, minmax(32px, 1fr)); gap: 4px; }
+        .symbol-dropdown-content { display: none; position: absolute; left: 100%; background-color: var(--bg-secondary); min-width: 280px; max-height: 200px; overflow-y: auto; box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2); z-index: 10; border-radius: 8px; border: 1px solid var(--border-color); padding: 8px; grid-template-columns: repeat(auto-fill, minmax(32px, 1fr)); gap: 4px; }
         .symbol-dropdown-content.visible { display: grid; }
         .symbol-btn {
             font-size: 18px;

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 </head>
 <body class="antialiased">
 
-    <div class="max-w-7xl mx-auto bg-secondary rounded-xl shadow-lg overflow-hidden my-8">
+    <div class="max-w-7xl mx-auto bg-secondary rounded-xl shadow-lg my-8">
         <div class="p-6 sm:p-8">
             <h1 class="text-2xl sm:text-3xl font-bold text-primary mb-4 text-center">Temario para Examen Final de Medicina Interna</h1>
             <div class="flex flex-col md:flex-row flex-wrap items-center justify-between gap-4 my-4">
@@ -315,7 +315,7 @@
     </div>
 
     <div id="notes-modal" class="modal-overlay">
-        <div class="modal-content notes-modal-content relative overflow-hidden">
+        <div class="modal-content notes-modal-content relative">
             <div class="resizer resizer-r"></div>
             <div class="resizer resizer-b"></div>
             <div class="resizer resizer-br"></div>
@@ -334,7 +334,7 @@
                     </div>
                 </div>
     
-                <div id="notes-main-content" class="flex flex-col flex-grow overflow-hidden">
+                <div id="notes-main-content" class="flex flex-col flex-grow">
                      <button id="notes-panel-toggle" class="absolute p-1 rounded-full text-text-secondary hover:bg-gray-200 dark:hover:bg-gray-700 transition-transform" title="Mostrar/Ocultar panel de notas">
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                           <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />


### PR DESCRIPTION
## Summary
- remove overflow clipping from note containers so special character panel can extend beyond editor bounds
- shift special character dropdown to display to the right of its trigger

## Testing
- `npm test` (fails: Missing script: test)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68954b8edf48832c807c32fabc157b4e