### PR TITLE
Add template library and toolbar menu

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ import { makeTableResizable } from './table-resize.js';
 import { setupAdvancedSearchReplace } from './search-replace.js';
 import { setupKeyboardShortcuts } from './shortcuts.js';
 import { setupCloudIntegration } from './cloud-sync.js';
+import { getTemplates, applyTemplate } from './template-library.js';
 
 const pdfjsLib = typeof window !== 'undefined' ? window['pdfjsLib'] : null;
 if (pdfjsLib) {
@@ -1850,6 +1851,34 @@ document.addEventListener('DOMContentLoaded', function () {
         });
         editorToolbar.appendChild(selectLineHeight);
 
+        // Template selector
+        const selectTemplate = document.createElement('select');
+        selectTemplate.className = 'toolbar-select';
+        selectTemplate.title = 'Plantillas';
+
+        const templatePlaceholder = document.createElement('option');
+        templatePlaceholder.value = '';
+        templatePlaceholder.textContent = 'Plantillas';
+        templatePlaceholder.disabled = true;
+        templatePlaceholder.selected = true;
+        selectTemplate.appendChild(templatePlaceholder);
+
+        getTemplates().forEach(name => {
+            const option = document.createElement('option');
+            option.value = name;
+            option.textContent = name;
+            selectTemplate.appendChild(option);
+        });
+
+        selectTemplate.addEventListener('change', async () => {
+            if (selectTemplate.value) {
+                await applyTemplate(selectTemplate.value, notesEditor);
+                selectTemplate.selectedIndex = 0;
+                notesEditor.focus();
+            }
+        });
+
+        editorToolbar.appendChild(selectTemplate);
 
         editorToolbar.appendChild(createSeparator());
 

--- a/template-library.js
+++ b/template-library.js
@@ -1,0 +1,24 @@
+const templatePaths = {
+  'Nota básica': 'templates/basic.md',
+  'Recordatorio': 'templates/recordatorio.html'
+};
+
+export function getTemplates() {
+  return Object.keys(templatePaths);
+}
+
+async function loadTemplate(name) {
+  const path = templatePaths[name];
+  const res = await fetch(path);
+  if (!res.ok) throw new Error('No se pudo cargar la plantilla');
+  return await res.text();
+}
+
+export async function applyTemplate(name, targetEl) {
+  const content = await loadTemplate(name);
+  if (templatePaths[name].endsWith('.md')) {
+    targetEl.textContent = content;
+  } else {
+    targetEl.innerHTML = content;
+  }
+}

--- a/templates/basic.md
+++ b/templates/basic.md
@@ -1,0 +1,6 @@
+## Nota Básica
+
+Este es un contenido de ejemplo para la plantilla en Markdown.
+
+- Elemento 1
+- Elemento 2

--- a/templates/recordatorio.html
+++ b/templates/recordatorio.html
@@ -1,0 +1,5 @@
+<h2>Recordatorio</h2>
+<ul>
+  <li>Tarea pendiente</li>
+  <li>Otra tarea</li>
+</ul>


### PR DESCRIPTION
## Summary
- add basic Markdown and HTML templates under new templates/ folder
- implement template-library.js to fetch and apply templates
- integrate "Plantillas" selector into editor toolbar

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6896cadea44c832c9e667fe90b8857e2