### PR TITLE
Add markdown preview panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -541,6 +541,15 @@
         Progreso guardado
     </div>
 
+    <!-- Markdown Preview Panel -->
+    <div id="preview-panel" class="fixed top-0 right-0 w-full md:w-1/3 h-full bg-white dark:bg-slate-800 shadow-lg transform translate-x-full transition-transform z-40 flex flex-col">
+        <div class="flex items-center justify-between p-2 border-b border-border-color">
+            <h3 class="font-bold">Preview</h3>
+            <button id="close-preview-panel" class="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700" aria-label="Cerrar panel de vista previa">&times;</button>
+        </div>
+        <div id="preview-content" class="flex-1 overflow-y-auto p-3"></div>
+    </div>
+
     <!-- IA Side Panel -->
     <div id="ai-panel" class="fixed top-0 right-0 w-full md:w-1/3 h-full bg-white dark:bg-slate-800 shadow-lg transform translate-x-full transition-transform z-50 flex flex-col">
         <div class="flex items-center justify-between p-2 border-b border-border-color">

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ import { makeTableResizable } from './table-resize.js';
 import { setupAdvancedSearchReplace } from './search-replace.js';
 import { setupKeyboardShortcuts } from './shortcuts.js';
 import { setupCloudIntegration } from './cloud-sync.js';
+import { renderMarkdown } from './markdown-preview.js';
 
 const pdfjsLib = typeof window !== 'undefined' ? window['pdfjsLib'] : null;
 if (pdfjsLib) {
@@ -163,7 +164,37 @@ document.addEventListener('DOMContentLoaded', function () {
     const aiCanvas = getElem('ai-canvas');
     const aiCanvasReasoning = getElem('ai-canvas-reasoning');
     let uploadedFileText = '';
-    
+
+    const previewPanel = getElem('preview-panel');
+    const previewContent = getElem('preview-content');
+    const closePreviewPanelBtn = getElem('close-preview-panel');
+    let previewVisible = false;
+
+    function updatePreview() {
+        if (!previewContent) return;
+        const content = notesEditor ? notesEditor.innerText : '';
+        previewContent.innerHTML = renderMarkdown(content);
+    }
+
+    function togglePreviewPanel() {
+        if (!previewPanel) return;
+        previewPanel.classList.toggle('translate-x-full');
+        previewVisible = !previewPanel.classList.contains('translate-x-full');
+        if (previewVisible) {
+            updatePreview();
+        }
+    }
+
+    if (closePreviewPanelBtn) {
+        closePreviewPanelBtn.addEventListener('click', togglePreviewPanel);
+    }
+
+    if (notesEditor) {
+        notesEditor.addEventListener('input', () => {
+            if (previewVisible) updatePreview();
+        });
+    }
+
     // References modal elements
     const referencesModal = getElem('references-modal');
     const referencesEditor = getElem('references-editor');
@@ -2042,6 +2073,9 @@ document.addEventListener('DOMContentLoaded', function () {
         editorToolbar.appendChild(resizeMinusBtn);
 
         // Eliminamos el botón de inserción de tablas y el separador asociado
+
+        const previewBtn = createButton('Mostrar/ocultar vista previa', 'Preview', null, null, togglePreviewPanel);
+        editorToolbar.appendChild(previewBtn);
 
         // Print/Save
         const printBtn = createButton('Imprimir o Guardar como PDF', '💾', null, null, () => {

--- a/markdown-preview.js
+++ b/markdown-preview.js
@@ -1,0 +1,5 @@
+import { marked } from 'https://cdn.jsdelivr.net/npm/marked/marked.esm.js';
+
+export function renderMarkdown(content) {
+  return marked.parse(content);
+}


### PR DESCRIPTION
## Summary
- add markdown preview module using marked
- integrate side panel to display rendered HTML and update with editor changes
- add toolbar button to toggle preview panel

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6896d241abd8832cbf6a8333f8fa479f