### PR TITLE
Improve printed index numbering and back link layout

### DIFF
--- a/index.css
+++ b/index.css
@@ -654,6 +654,8 @@ table.resizable-table th {
         }
         #print-index ol {
             margin-left: 1.5rem;
+            list-style: none;
+            padding-left: 0;
         }
         #print-index a {
             text-decoration: none;
@@ -666,9 +668,10 @@ table.resizable-table th {
             color: #9ca3af;
         }
         .back-to-index {
-            display: inline-block;
+            display: block;
+            text-align: right;
             margin-bottom: 0.5rem;
-            font-size: 0.875rem;
+            font-size: 0.75rem;
         }
 
 

--- a/index.js
+++ b/index.js
@@ -3058,7 +3058,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 header.textContent = sectionTitle;
                 indexContainer.appendChild(header);
                 currentOl = document.createElement('ol');
-                currentOl.start = counter;
                 indexContainer.appendChild(currentOl);
             } else {
                 const topicId = row.dataset.topicId;
@@ -3070,7 +3069,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     const li = document.createElement('li');
                     const link = document.createElement('a');
                     link.href = `#print-${topicId}`;
-                    link.textContent = title;
+                    link.textContent = `${counter}. ${title}`;
                     link.className = hasNotes ? 'topic-developed' : 'topic-pending';
                     li.appendChild(link);
                     currentOl.appendChild(li);
@@ -3088,6 +3087,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
                 const titleEl = document.createElement('h2');
                 titleEl.textContent = `${counter}. ${title}`;
+                if (!hasNotes) {
+                    titleEl.style.color = '#9ca3af';
+                }
                 topicWrapper.appendChild(titleEl);
 
                 if (hasNotes) {


### PR DESCRIPTION
## Summary
- Display continuous topic numbers across sections in printed index
- Show undeveloped topics in gray and place compact "Volver al índice" link at top-right of each topic page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898fa14c8c8832c82fd5bc28b7de9a9