### PR TITLE
Enable resizing for tables embedded in notes

### DIFF
--- a/index.css
+++ b/index.css
@@ -332,12 +332,16 @@ table.resizable-table th {
 
 table.resizable-table .table-resize-handle {
     position: absolute;
-    width: 10px;
-    height: 10px;
+    width: 8px;
+    height: 8px;
     right: 0;
     bottom: 0;
     cursor: se-resize;
-    background: #999;
+    background: transparent;
+    border-right: 2px solid var(--text-muted);
+    border-bottom: 2px solid var(--text-muted);
+    opacity: 0.7;
+    box-sizing: border-box;
 }
 
 /* Floating image styles */

--- a/index.css
+++ b/index.css
@@ -322,9 +322,22 @@
         }
 
 /* Basic styles for resizable tables */
+table.resizable-table {
+    position: relative;
+}
 table.resizable-table td,
 table.resizable-table th {
     position: relative;
+}
+
+table.resizable-table .table-resize-handle {
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    right: 0;
+    bottom: 0;
+    cursor: se-resize;
+    background: #999;
 }
 
 /* Floating image styles */

--- a/index.js
+++ b/index.js
@@ -2728,12 +2728,15 @@ document.addEventListener('DOMContentLoaded', function () {
         }
         // initialize resizers on newly inserted tables (defer to allow DOM insertion)
         setTimeout(() => {
-            const tables = notesEditor.querySelectorAll('table.resizable-table');
+            const tables = notesEditor.querySelectorAll('table');
             tables.forEach(t => initTableResize(t));
         }, 50);
     }
     function initTableResize(table) {
+        if (table.dataset.resizableInitialized === 'true') return;
+        table.classList.add('resizable-table');
         makeTableResizable(table);
+        table.dataset.resizableInitialized = 'true';
     }
 
     function renderNotesList() {
@@ -2788,6 +2791,7 @@ document.addEventListener('DOMContentLoaded', function () {
         
         notesModalTitle.textContent = note.title || `Nota ${index + 1}`;
         notesEditor.innerHTML = note.content || '<p><br></p>';
+        notesEditor.querySelectorAll('table').forEach(initTableResize);
 
         renderNotesList();
         notesEditor.focus();
@@ -3450,6 +3454,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     const reader = new FileReader();
                     reader.onload = (e) => {
                         notesEditor.innerHTML = e.target.result;
+                        notesEditor.querySelectorAll('table').forEach(initTableResize);
                     };
                     reader.readAsText(file);
                 }
@@ -3989,7 +3994,7 @@ document.addEventListener('DOMContentLoaded', function () {
         populateIconPicker();
         loadState();
         setupEventListeners();
-        document.querySelectorAll('table.resizable-table').forEach(initTableResize);
+        document.querySelectorAll('table').forEach(initTableResize);
         applyTheme(document.documentElement.dataset.theme || 'default');
         setupAdvancedSearchReplace();
         setupKeyboardShortcuts();


### PR DESCRIPTION
## Summary
- Initialize resizing on all tables within notes
- Prevent duplicate initialization by marking processed tables
- Apply resizable behavior after loading or importing note content
- Add a bottom-right corner handle to resize entire tables

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689be177fe74832c808bc050ecb490e6