### PR TITLE
Add margin-based indentation for note callouts

### DIFF
--- a/index.css
+++ b/index.css
@@ -726,6 +726,7 @@ table.resizable-table .table-resize-handle {
 
 /* Note callout styles */
 .note-callout {
+    box-sizing: border-box;
     border-radius: 8px;
     border: 2px solid var(--border-color);
     padding: 8px;

--- a/index.js
+++ b/index.js
@@ -369,13 +369,22 @@ document.addEventListener('DOMContentLoaded', function () {
             btn.innerHTML = content;
             btn.addEventListener('click', (e) => {
                 e.preventDefault();
-                if (command) {
-                    document.execCommand(command, false, value);
+                if (command === 'indent' || command === 'outdent') {
+                    const blocks = getSelectedBlocksSN();
+                    const handled = applyIndentation(blocks, command === 'indent');
+                    if (!handled) {
+                        document.execCommand(command, false, value);
+                    }
                     collapseSelectionSN();
-                }
-                if (action) {
-                    action();
-                    collapseSelectionSN();
+                } else {
+                    if (command) {
+                        document.execCommand(command, false, value);
+                        collapseSelectionSN();
+                    }
+                    if (action) {
+                        action();
+                        collapseSelectionSN();
+                    }
                 }
                 subNoteEditor.focus();
             });
@@ -1587,6 +1596,32 @@ document.addEventListener('DOMContentLoaded', function () {
 
         return [startBlock]; // Fallback
     }
+
+    function applyIndentation(blocks, indent) {
+        const sel = window.getSelection();
+        const anchor = sel && sel.anchorNode ? (sel.anchorNode.nodeType === 1 ? sel.anchorNode : sel.anchorNode.parentElement) : null;
+        const callout = anchor ? anchor.closest('.note-callout') : null;
+        if (!callout) return false;
+
+        const targets = blocks.filter(block => block && callout.contains(block) && block !== callout);
+        if (targets.length === 0) return true;
+
+        const step = 24;
+        targets.forEach(block => {
+            const current = parseInt(block.style.marginInlineStart) || 0;
+            if (indent) {
+                block.style.marginInlineStart = `${current + step}px`;
+            } else {
+                const newVal = Math.max(0, current - step);
+                if (newVal === 0) {
+                    block.style.removeProperty('margin-inline-start');
+                } else {
+                    block.style.marginInlineStart = `${newVal}px`;
+                }
+            }
+        });
+        return true;
+    }
     
     function setupEditorToolbar() {
         editorToolbar.innerHTML = ''; // Clear existing toolbar
@@ -1611,15 +1646,24 @@ document.addEventListener('DOMContentLoaded', function () {
             btn.innerHTML = content;
             btn.addEventListener('click', (e) => {
                 e.preventDefault();
-                if (command) {
-                    document.execCommand(command, false, value);
-                    // Collapse the selection after applying the command
+                if (command === 'indent' || command === 'outdent') {
+                    const blocks = getSelectedBlockElements();
+                    const handled = applyIndentation(blocks, command === 'indent');
+                    if (!handled) {
+                        document.execCommand(command, false, value);
+                    }
                     collapseSelection(notesEditor);
-                }
-                if (action) {
-                    action();
-                    // Collapse again after custom actions
-                    collapseSelection(notesEditor);
+                } else {
+                    if (command) {
+                        document.execCommand(command, false, value);
+                        // Collapse the selection after applying the command
+                        collapseSelection(notesEditor);
+                    }
+                    if (action) {
+                        action();
+                        // Collapse again after custom actions
+                        collapseSelection(notesEditor);
+                    }
                 }
                 notesEditor.focus();
             });


### PR DESCRIPTION
## Summary
- handle indent/outdent inside note callouts by applying margin to inner blocks instead of resizing the callout
- ensure note callouts use border-box sizing so indentation doesn't shift their width

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689d61b458dc832c921bf577c72a138c