### PR TITLE
feat: allow inline dragging of images in editor

### DIFF
--- a/index.css
+++ b/index.css
@@ -739,3 +739,14 @@ table.resizable-table .table-resize-handle {
 .note-gray { background-color: #f3f4f6; border-color: #6b7280; }
 .note-shadow { box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
 .predef-note-btn { margin:0; cursor:pointer; }
+
+#drop-caret {
+    display: inline-block;
+    width: 1px;
+    height: 1em;
+    background: var(--btn-primary-bg);
+    vertical-align: bottom;
+}
+.img-dragging {
+    opacity: 0.6;
+}

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ import { makeTableResizable } from './table-resize.js';
 import { setupAdvancedSearchReplace } from './search-replace.js';
 import { setupKeyboardShortcuts } from './shortcuts.js';
 import { setupCloudIntegration } from './cloud-sync.js';
+import { enableInlineImageDrag } from './inline-image-drag.js';
 
 const pdfjsLib = typeof window !== 'undefined' ? window['pdfjsLib'] : null;
 if (pdfjsLib) {
@@ -112,6 +113,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const notesModal = getElem('notes-modal');
     const notesModalTitle = getElem('notes-modal-title');
     const notesEditor = getElem('notes-editor');
+    enableInlineImageDrag(notesEditor);
     const editorToolbar = notesModal.querySelector('.editor-toolbar');
     const saveNoteBtn = getElem('save-note-btn');
     const saveAndCloseNoteBtn = getElem('save-and-close-note-btn');
@@ -324,6 +326,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const subNoteModal = getElem('subnote-modal');
     const subNoteTitle = getElem('subnote-title');
     const subNoteEditor = getElem('subnote-editor');
+    enableInlineImageDrag(subNoteEditor);
     const subNoteToolbar = getElem('subnote-toolbar');
     const deleteSubnoteBtn = getElem('delete-subnote-btn');
     const saveCloseSubnoteBtn = getElem('save-close-subnote-btn');

--- a/inline-image-drag.js
+++ b/inline-image-drag.js
@@ -1,0 +1,81 @@
+export function enableInlineImageDrag(editor) {
+  if (!editor) return;
+  let draggingImg = null;
+  let caret = null;
+  let started = false;
+
+  function rangeFromPoint(x, y) {
+    if (document.caretRangeFromPoint) {
+      return document.caretRangeFromPoint(x, y);
+    }
+    const pos = document.caretPositionFromPoint && document.caretPositionFromPoint(x, y);
+    if (!pos) return null;
+    const r = document.createRange();
+    r.setStart(pos.offsetNode, pos.offset);
+    r.collapse(true);
+    return r;
+  }
+
+  function clearCaret() {
+    if (caret && caret.parentNode) {
+      caret.parentNode.removeChild(caret);
+    }
+    caret = null;
+  }
+
+  function cancelDrag() {
+    clearCaret();
+    if (draggingImg) {
+      draggingImg.classList.remove('img-dragging');
+      draggingImg = null;
+    }
+    document.removeEventListener('mousemove', onMove);
+    document.removeEventListener('mouseup', onUp);
+    document.removeEventListener('keydown', onKey);
+    started = false;
+  }
+
+  function onMove(e) {
+    if (!draggingImg) return;
+    started = true;
+    e.preventDefault();
+    const r = rangeFromPoint(e.clientX, e.clientY);
+    if (!r) return;
+    if (!caret) {
+      caret = document.createElement('span');
+      caret.id = 'drop-caret';
+      caret.textContent = '\u200b';
+    }
+    r.insertNode(caret);
+  }
+
+  function onUp(e) {
+    if (!draggingImg) return;
+    if (started && caret && caret.parentNode) {
+      caret.parentNode.insertBefore(draggingImg, caret);
+    }
+    cancelDrag();
+  }
+
+  function onKey(e) {
+    if (e.key === 'Escape') {
+      cancelDrag();
+    }
+  }
+
+  editor.addEventListener('mousedown', (e) => {
+    if (e.target.tagName !== 'IMG') return;
+    draggingImg = e.target;
+    draggingImg.classList.add('img-dragging');
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+    document.addEventListener('keydown', onKey);
+  });
+
+  // Disable native drag behaviour
+  editor.addEventListener('dragstart', (e) => {
+    if (e.target.tagName === 'IMG') {
+      e.preventDefault();
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- enable custom inline drag for images using Range API
- show drop caret and move image without extra wrappers
- apply dragging support to main and sub-note editors

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689e87662344832cb4584ae5b2957d7c