### PR TITLE
feat: enable inline image drag

### DIFF
--- a/image-drag-inline.js
+++ b/image-drag-inline.js
@@ -1,0 +1,104 @@
+export function setupInlineImageDrag(editor) {
+  if (!editor) return { destroy: () => {} };
+
+  let draggingImg = null;
+  let dropCaret = null;
+
+  editor.addEventListener('mousedown', onMouseDown);
+  editor.addEventListener('dragstart', disableNativeDnD);
+  editor.addEventListener('drop', disableNativeDnD);
+  editor.addEventListener('dragover', disableNativeDnD);
+
+  function disableNativeDnD(e) {
+    if (e.target && e.target.tagName === 'IMG') {
+      e.preventDefault();
+    }
+  }
+
+  function onMouseDown(e) {
+    if (e.button !== 0 || e.target.tagName !== 'IMG') return;
+    draggingImg = e.target;
+    draggingImg.classList.add('img-dragging');
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+    document.addEventListener('keydown', onKeyDown);
+    e.preventDefault();
+  }
+
+  function onMouseMove(e) {
+    if (!draggingImg) return;
+    e.preventDefault();
+    const range = caretRangeFromPoint(e.clientX, e.clientY);
+    if (!range || !editor.contains(range.startContainer)) return;
+    showDropCaret(range);
+  }
+
+  function onMouseUp(e) {
+    if (!draggingImg) return;
+    e.preventDefault();
+    if (dropCaret && dropCaret.parentNode) {
+      dropCaret.parentNode.insertBefore(draggingImg, dropCaret);
+      const sel = window.getSelection();
+      const range = document.createRange();
+      range.setStartAfter(draggingImg);
+      range.collapse(true);
+      sel.removeAllRanges();
+      sel.addRange(range);
+      dropCaret.remove();
+    }
+    draggingImg.classList.remove('img-dragging');
+    cleanup();
+  }
+
+  function onKeyDown(e) {
+    if (e.key === 'Escape' && draggingImg) {
+      if (dropCaret) dropCaret.remove();
+      draggingImg.classList.remove('img-dragging');
+      cleanup();
+    }
+  }
+
+  function cleanup() {
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseup', onMouseUp);
+    document.removeEventListener('keydown', onKeyDown);
+    draggingImg = null;
+    dropCaret = null;
+  }
+
+  function showDropCaret(range) {
+    if (!dropCaret) {
+      dropCaret = document.createElement('span');
+      dropCaret.id = 'drop-caret';
+      dropCaret.textContent = '\u200b';
+    }
+    if (dropCaret.parentNode) dropCaret.parentNode.removeChild(dropCaret);
+    range.insertNode(dropCaret);
+  }
+
+  function caretRangeFromPoint(x, y) {
+    if (document.caretRangeFromPoint) {
+      return document.caretRangeFromPoint(x, y);
+    }
+    if (document.caretPositionFromPoint) {
+      const pos = document.caretPositionFromPoint(x, y);
+      if (pos) {
+        const range = document.createRange();
+        range.setStart(pos.offsetNode, pos.offset);
+        range.collapse(true);
+        return range;
+      }
+    }
+    return null;
+  }
+
+  return {
+    destroy() {
+      editor.removeEventListener('mousedown', onMouseDown);
+      editor.removeEventListener('dragstart', disableNativeDnD);
+      editor.removeEventListener('drop', disableNativeDnD);
+      editor.removeEventListener('dragover', disableNativeDnD);
+      cleanup();
+    }
+  };
+}

--- a/index.css
+++ b/index.css
@@ -739,3 +739,16 @@ table.resizable-table .table-resize-handle {
 .note-gray { background-color: #f3f4f6; border-color: #6b7280; }
 .note-shadow { box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
 .predef-note-btn { margin:0; cursor:pointer; }
+
+/* Inline image drag marker */
+.img-dragging {
+    opacity: 0.5;
+}
+
+#drop-caret {
+    display: inline-block;
+    width: 1px;
+    background: var(--text-primary);
+    height: 1em;
+    vertical-align: bottom;
+}

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ import { makeTableResizable } from './table-resize.js';
 import { setupAdvancedSearchReplace } from './search-replace.js';
 import { setupKeyboardShortcuts } from './shortcuts.js';
 import { setupCloudIntegration } from './cloud-sync.js';
+import { setupInlineImageDrag } from './image-drag-inline.js';
 
 const pdfjsLib = typeof window !== 'undefined' ? window['pdfjsLib'] : null;
 if (pdfjsLib) {
@@ -4272,6 +4273,8 @@ document.addEventListener('DOMContentLoaded', function () {
         setupAdvancedSearchReplace();
         setupKeyboardShortcuts();
         setupCloudIntegration();
+        setupInlineImageDrag(notesEditor);
+        if (subNoteEditor) setupInlineImageDrag(subNoteEditor);
     }
 
     init();


### PR DESCRIPTION
## Summary
- allow inline images to be repositioned with a custom caret drag-and-drop
- include CSS for drop caret marker and dragging state

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689e87662344832cb4584ae5b2957d7c