### PR TITLE
Adjust padding around subnote editor

### DIFF
--- a/index.css
+++ b/index.css
@@ -106,6 +106,10 @@
         .modal-overlay.visible .modal-content { transform: translateY(0); }
         
         .notes-modal-content { max-width: 900px; height: 95vh; max-height: 95vh; padding: 0; }
+
+        #subnote-modal .notes-modal-content {
+            padding: 1rem;
+        }
         
         .note-icon, .link-anchor, .edit-link-icon, .print-section-btn { display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: 50%; transition: background-color 0.2s, color 0.2s, opacity 0.2s, filter 0.2s; cursor: pointer; }
         .note-icon:hover, .link-anchor:hover, .edit-link-icon:hover, .print-section-btn:hover { background-color: rgba(0,0,0,0.1); }


### PR DESCRIPTION
## Summary
- Add dedicated padding to the subnote modal so its editor has consistent margins with the main editor

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fa99a4e48832c8918e90cddbe57e6