### PR TITLE
Insert blank lines on editor clicks and add delete mode

### DIFF
--- a/index.css
+++ b/index.css
@@ -244,6 +244,7 @@
             min-height: 26px;
         }
         .toolbar-btn:hover { background-color: var(--bg-tertiary); }
+        .toolbar-btn.active { background-color: var(--bg-tertiary); }
         .toolbar-select {
             font-size: 12px;
             background-color: var(--bg-secondary);


### PR DESCRIPTION
## Summary
- Force a default blank line insertion when clicking between blocks in the notes editor
- Add toolbar button to toggle delete mode and remove clicked elements
- Highlight active toolbar buttons with a new style

## Testing
- `npm test` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689fc0277764832caf5219bbc0b9d8d6