### PR TITLE
feat: add inline lamp note component

### DIFF
--- a/index.css
+++ b/index.css
@@ -745,3 +745,28 @@ table.resizable-table .table-resize-handle {
 .note-gray { background-color: #f3f4f6; border-color: #6b7280; }
 .note-shadow { box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
 .predef-note-btn { margin:0; cursor:pointer; }
+/* Inline lamp note */
+.lamp-note {
+  position: relative;
+  cursor: pointer;
+  color: inherit;
+}
+.lamp-note .lamp-note-content {
+  display: none;
+  position: absolute;
+  z-index: 10;
+  left: 0.5em;
+  top: -0.2em;
+  padding: 0.25em 0.5em;
+  border: 1px solid currentColor;
+  border-radius: 0.25em;
+  background: var(--bg-secondary);
+  color: inherit;
+  font-size: inherit;
+  font-family: inherit;
+  white-space: pre-wrap;
+}
+.lamp-note:hover .lamp-note-content,
+.lamp-note:focus-within .lamp-note-content {
+  display: block;
+}

--- a/index.html
+++ b/index.html
@@ -642,6 +642,7 @@
 
     <div id="print-area" class="hidden"></div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
+<script src="lamp-note.js" type="module"></script>
 <script src="index.js" type="module"></script>
 </body>
 </html>

--- a/lamp-note.js
+++ b/lamp-note.js
@@ -1,0 +1,16 @@
+export function insertLampNote(text = '') {
+  const sup = document.createElement('sup');
+  sup.className = 'lamp-note';
+  sup.innerHTML = `💡<span class="lamp-note-content" contenteditable="true">${text}</span>`;
+  const sel = window.getSelection();
+  if (!sel || !sel.rangeCount) return;
+  const range = sel.getRangeAt(0);
+  range.insertNode(sup);
+  range.setStartAfter(sup);
+  range.collapse(true);
+  sel.removeAllRanges();
+  sel.addRange(range);
+  const note = sup.querySelector('.lamp-note-content');
+  note.focus();
+}
+window.insertLampNote = insertLampNote;


### PR DESCRIPTION
## Summary
- add CSS and JS for inline lamp notes that show editable content on hover
- expose `insertLampNote` helper and load script on main page

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0e30deac8832c8accb95b740b9b32