### PR TITLE
Add resizable callout component

### DIFF
--- a/div-resize.js
+++ b/div-resize.js
@@ -1,0 +1,55 @@
+export function makeResizable(el) {
+  if (!el) return;
+  el.classList.add('resizable');
+  if (getComputedStyle(el).position === 'static') {
+    el.style.position = 'relative';
+  }
+  const handle = document.createElement('div');
+  handle.className = 'resizable-handle';
+  el.appendChild(handle);
+
+  let startX = 0;
+  let startWidth = 0;
+
+  function startResize(e) {
+    e.preventDefault();
+    startX = e.clientX;
+    startWidth = el.getBoundingClientRect().width;
+    document.addEventListener('pointermove', onResize);
+    document.addEventListener('pointerup', stopResize);
+  }
+
+  function onResize(e) {
+    const dx = e.clientX - startX;
+    const parentWidth = el.parentElement ? el.parentElement.getBoundingClientRect().width : Infinity;
+    let newWidth = startWidth + dx;
+    newWidth = Math.max(200, Math.min(newWidth, parentWidth));
+    el.style.width = Math.round(newWidth) + 'px';
+  }
+
+  function stopResize() {
+    document.removeEventListener('pointermove', onResize);
+    document.removeEventListener('pointerup', stopResize);
+  }
+
+  handle.addEventListener('pointerdown', startResize);
+}
+
+export function wrapSelectionAsResizable() {
+  const sel = window.getSelection();
+  if (!sel || !sel.rangeCount) return null;
+  const range = sel.getRangeAt(0);
+  if (range.collapsed) return null;
+  const wrapper = document.createElement('div');
+  const contents = range.extractContents();
+  wrapper.appendChild(contents);
+  range.insertNode(wrapper);
+  makeResizable(wrapper);
+  const width = wrapper.getBoundingClientRect().width;
+  wrapper.style.width = Math.max(200, width) + 'px';
+  sel.removeAllRanges();
+  const newRange = document.createRange();
+  newRange.selectNodeContents(wrapper);
+  sel.addRange(newRange);
+  return wrapper;
+}

--- a/index.css
+++ b/index.css
@@ -745,3 +745,19 @@ table.resizable-table .table-resize-handle {
 .note-gray { background-color: #f3f4f6; border-color: #6b7280; }
 .note-shadow { box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
 .predef-note-btn { margin:0; cursor:pointer; }
+/* Resizable elements */
+.resizable {
+    position: relative;
+    max-width: 100%;
+    min-width: 200px;
+}
+.resizable-handle {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 8px;
+    height: 100%;
+    cursor: ew-resize;
+    background: rgba(0,0,0,0.2);
+    touch-action: none;
+}

--- a/index.js
+++ b/index.js
@@ -9,9 +9,12 @@ import { GoogleGenAI } from "@google/genai";
 // inline IndexedDB implementation and keeps the rest of the code unchanged.
 import db from './db.js';
 import { makeTableResizable } from './table-resize.js';
+import { makeResizable, wrapSelectionAsResizable } from './div-resize.js';
 import { setupAdvancedSearchReplace } from './search-replace.js';
 import { setupKeyboardShortcuts } from './shortcuts.js';
 import { setupCloudIntegration } from './cloud-sync.js';
+window.makeResizable = makeResizable;
+window.wrapSelectionAsResizable = wrapSelectionAsResizable;
 
 const pdfjsLib = typeof window !== 'undefined' ? window['pdfjsLib'] : null;
 if (pdfjsLib) {


### PR DESCRIPTION
## Summary
- add generic `makeResizable` helper and selection wrapper
- expose resizable functions on `window` and add CSS for resize handle

## Testing
- `npm test` *(fails: Missing script "test" )*


------
https://chatgpt.com/codex/tasks/task_e_68a112151848832c889d94b478c80ac7