### PR TITLE
Add lateral resizing for note callouts

### DIFF
--- a/callout-resize.js
+++ b/callout-resize.js
@@ -1,0 +1,30 @@
+export function makeCalloutResizable(callout, { minWidth = 100 } = {}) {
+  let startX = 0;
+  let startWidth = 0;
+  let isResizing = false;
+
+  callout.style.position = callout.style.position || 'relative';
+  const handle = document.createElement('div');
+  handle.className = 'callout-resize-handle';
+  callout.appendChild(handle);
+
+  handle.addEventListener('mousedown', e => {
+    e.preventDefault();
+    e.stopPropagation();
+    isResizing = true;
+    startX = e.clientX;
+    startWidth = callout.offsetWidth;
+  });
+
+  document.addEventListener('mousemove', e => {
+    if (!isResizing) return;
+    const dx = e.clientX - startX;
+    const newWidth = Math.max(minWidth, startWidth + dx);
+    callout.style.width = newWidth + 'px';
+  });
+
+  document.addEventListener('mouseup', () => {
+    if (!isResizing) return;
+    isResizing = false;
+  });
+}

--- a/index.css
+++ b/index.css
@@ -732,10 +732,23 @@ table.resizable-table .table-resize-handle {
 
 /* Note callout styles */
 .note-callout {
+    position: relative;
     border-radius: 8px;
     border: 2px solid var(--border-color);
     padding: 8px;
     margin: 8px 0;
+}
+.note-callout .callout-resize-handle {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 6px;
+    height: 100%;
+    cursor: ew-resize;
+    background: transparent;
+    border-right: 2px solid var(--text-muted);
+    opacity: 0.7;
+    box-sizing: border-box;
 }
 .note-blue { background-color: #dbeafe; border-color: #3b82f6; }
 .note-green { background-color: #d1fae5; border-color: #10b981; }

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ import { GoogleGenAI } from "@google/genai";
 // inline IndexedDB implementation and keeps the rest of the code unchanged.
 import db from './db.js';
 import { makeTableResizable } from './table-resize.js';
+import { makeCalloutResizable } from './callout-resize.js';
 import { setupAdvancedSearchReplace } from './search-replace.js';
 import { setupKeyboardShortcuts } from './shortcuts.js';
 import { setupCloudIntegration } from './cloud-sync.js';
@@ -2186,6 +2187,7 @@ document.addEventListener('DOMContentLoaded', function () {
         } else {
             currentCallout.classList.remove('note-shadow');
         }
+        initCalloutResize(currentCallout);
         const range = document.createRange();
         range.selectNodeContents(currentCallout);
         range.collapse(false);
@@ -2933,6 +2935,12 @@ document.addEventListener('DOMContentLoaded', function () {
         table.dataset.resizableInitialized = 'true';
     }
 
+    function initCalloutResize(callout) {
+        if (callout.dataset.resizableInitialized === 'true') return;
+        makeCalloutResizable(callout);
+        callout.dataset.resizableInitialized = 'true';
+    }
+
     function renderNotesList() {
         notesList.innerHTML = '';
         if (currentNotesArray.length === 0) {
@@ -2986,6 +2994,7 @@ document.addEventListener('DOMContentLoaded', function () {
         notesModalTitle.textContent = note.title || `Nota ${index + 1}`;
         notesEditor.innerHTML = note.content || '<p><br></p>';
         notesEditor.querySelectorAll('table').forEach(initTableResize);
+        notesEditor.querySelectorAll('.note-callout').forEach(initCalloutResize);
 
         renderNotesList();
         notesEditor.focus();
@@ -3649,6 +3658,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     reader.onload = (e) => {
                         notesEditor.innerHTML = e.target.result;
                         notesEditor.querySelectorAll('table').forEach(initTableResize);
+                        notesEditor.querySelectorAll('.note-callout').forEach(initCalloutResize);
                     };
                     reader.readAsText(file);
                 }
@@ -4269,6 +4279,7 @@ document.addEventListener('DOMContentLoaded', function () {
         loadState();
         setupEventListeners();
         document.querySelectorAll('table').forEach(initTableResize);
+        document.querySelectorAll('.note-callout').forEach(initCalloutResize);
         applyTheme(document.documentElement.dataset.theme || 'default');
         setupAdvancedSearchReplace();
         setupKeyboardShortcuts();


### PR DESCRIPTION
## Summary
- allow colored note callouts to be resized horizontally
- initialize resizable handles when notes are created, loaded, or imported

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a11768e558832cae33b2d71db489d9