### PR TITLE
feat: allow lateral resizing of notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ This contains everything you need to run your app locally.
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+### Features
+
+- Nueva herramienta en el editor para redimensionar lateralmente notas con fondo de color mediante el botón ↔️ de la barra de herramientas.

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ This contains everything you need to run your app locally.
 
 ### Features
 
-- Nueva herramienta en el editor para redimensionar lateralmente notas con fondo de color mediante el botón ↔️ de la barra de herramientas.
+- Nueva herramienta en el editor para redimensionar lateralmente notas o bloques HTML insertados mediante el botón ↔️ de la barra de herramientas.

--- a/index.css
+++ b/index.css
@@ -737,6 +737,12 @@ table.resizable-table .table-resize-handle {
     padding: 8px;
     margin: 8px 0;
 }
+.note-resizable {
+    resize: horizontal;
+    overflow: auto;
+    display: inline-block;
+    max-width: 100%;
+}
 .note-blue { background-color: #dbeafe; border-color: #3b82f6; }
 .note-green { background-color: #d1fae5; border-color: #10b981; }
 .note-yellow { background-color: #fef9c3; border-color: #eab308; }

--- a/index.js
+++ b/index.js
@@ -2058,16 +2058,16 @@ document.addEventListener('DOMContentLoaded', function () {
             const selection = window.getSelection();
             const node = selection && selection.focusNode;
             const element = node ? (node.nodeType === Node.ELEMENT_NODE ? node : node.parentElement) : null;
-            const callout = element ? element.closest('.note-callout') : null;
-            if (!callout) {
-                showAlert('Selecciona una nota para redimensionar.');
+            const block = element ? element.closest('.note-callout, div, blockquote') : null;
+            if (!block || block === notesEditor) {
+                showAlert('Selecciona un bloque para redimensionar.');
                 return;
             }
-            callout.classList.toggle('note-resizable');
-            if (callout.classList.contains('note-resizable')) {
-                callout.style.width = callout.offsetWidth + 'px';
+            block.classList.toggle('note-resizable');
+            if (block.classList.contains('note-resizable')) {
+                block.style.width = block.offsetWidth + 'px';
             } else {
-                callout.style.width = '';
+                block.style.width = '';
             }
         });
         editorToolbar.appendChild(resizeCalloutBtn);

--- a/index.js
+++ b/index.js
@@ -2054,6 +2054,24 @@ document.addEventListener('DOMContentLoaded', function () {
         });
         editorToolbar.appendChild(calloutBtn);
 
+        const resizeCalloutBtn = createButton('Redimensionar nota', '↔️', null, null, () => {
+            const selection = window.getSelection();
+            const node = selection && selection.focusNode;
+            const element = node ? (node.nodeType === Node.ELEMENT_NODE ? node : node.parentElement) : null;
+            const callout = element ? element.closest('.note-callout') : null;
+            if (!callout) {
+                showAlert('Selecciona una nota para redimensionar.');
+                return;
+            }
+            callout.classList.toggle('note-resizable');
+            if (callout.classList.contains('note-resizable')) {
+                callout.style.width = callout.offsetWidth + 'px';
+            } else {
+                callout.style.width = '';
+            }
+        });
+        editorToolbar.appendChild(resizeCalloutBtn);
+
         const subnoteSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-file-pen-line w-5 h-5"><path d="m18 12-4 4-1 4 4-1 4-4"/><path d="M12 22h6"/><path d="M7 12h10"/><path d="M5 17h10"/><path d="M5 7h10"/><path d="M15 2H9a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/></svg>`;
         // El botón ahora crea una sub-nota en lugar de un Post-it
         editorToolbar.appendChild(createButton('Añadir Sub-nota', subnoteSVG, null, null, createSubnoteLink));


### PR DESCRIPTION
## Summary
- add toolbar button to toggle horizontal resizing on colored note boxes
- style resizable notes with horizontal resize behavior and max width
- document new editor feature in README

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a11768e558832cae33b2d71db489d9