### PR TITLE
feat: add resizable text boxes

### DIFF
--- a/index.css
+++ b/index.css
@@ -745,3 +745,33 @@ table.resizable-table .table-resize-handle {
 .note-gray { background-color: #f3f4f6; border-color: #6b7280; }
 .note-shadow { box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
 .predef-note-btn { margin:0; cursor:pointer; }
+
+.resizable-text-box {
+    position: relative;
+    background-color: #fef9c3;
+    border: 1px solid var(--border-color);
+    padding: 8px;
+    display: inline-block;
+    min-width: 100px;
+    max-width: 100%;
+    border-radius: 4px;
+    box-sizing: border-box;
+}
+.resizable-text-box .resize-handle {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 8px;
+    height: 100%;
+    cursor: ew-resize;
+    background: transparent;
+    border-right: 2px solid var(--text-muted);
+    opacity: 0.7;
+    box-sizing: border-box;
+}
+
+@media print {
+    .resizable-text-box .resize-handle {
+        display: none;
+    }
+}


### PR DESCRIPTION
## Summary
- add toolbar button to insert horizontally resizable text boxes
- implement resize handle logic and styles for text boxes
- initialize resizable boxes when loading or importing notes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a11768e558832cae33b2d71db489d9