### PR TITLE
feat: inline subnote icon with tooltip

### DIFF
--- a/index.css
+++ b/index.css
@@ -219,9 +219,23 @@
 
 /* Enlaces de sub-notas: estilo distintivo con subrayado punteado */
 .subnote-link {
-    text-decoration: underline dotted;
+    text-decoration: none;
     cursor: pointer;
     color: inherit;
+    vertical-align: sub;
+    font-size: 0.8em;
+}
+
+#subnote-tooltip {
+    position: absolute;
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    padding: 4px 6px;
+    border-radius: 4px;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    display: none;
+    z-index: 1000;
+    max-width: 200px;
 }
         /* Toolbar styles */
         .toolbar-separator {

--- a/index.html
+++ b/index.html
@@ -639,7 +639,7 @@
     </div>
 
     <button id="open-ai-panel" class="fixed bottom-4 right-4 p-3 bg-indigo-600 text-white rounded-full shadow-lg" aria-label="Abrir asistente de IA">🤖</button>
-
+    <div id="subnote-tooltip"></div>
     <div id="print-area" class="hidden"></div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 <script src="index.js" type="module"></script>


### PR DESCRIPTION
## Summary
- allow inserting an inline lightbulb icon as a subscript note marker
- show and edit brief notes linked to the icon and reveal them as tooltips on hover

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check index.js`


------
https://chatgpt.com/codex/tasks/task_e_68a14221c3ac832c82c69ae0517b3dbd