### PR TITLE
feat: notas en línea con icono

### DIFF
--- a/index.css
+++ b/index.css
@@ -223,6 +223,27 @@
     cursor: pointer;
     color: inherit;
 }
+/* Icono de nota en línea como subíndice */
+.inline-note {
+    vertical-align: sub;
+    font-size: 0.8em;
+    cursor: pointer;
+    color: inherit;
+}
+
+/* Tooltip para mostrar el contenido de la nota en línea */
+.inline-note-tooltip {
+    position: absolute;
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.375rem;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    max-width: 300px;
+    z-index: 1000;
+    pointer-events: none;
+}
         /* Toolbar styles */
         .toolbar-separator {
             border-left: 1px solid var(--border-color);


### PR DESCRIPTION
## Summary
- insertar botón para añadir notas en línea con icono
- mostrar notas en tooltip y abrir editor al hacer clic

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a14221c3ac832c82c69ae0517b3dbd