### PR TITLE
feat: icon picker for inline notes and persistent tooltips

### DIFF
--- a/index.css
+++ b/index.css
@@ -101,9 +101,12 @@
         
         .modal-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.5); display: flex; align-items: center; justify-content: center; z-index: 1000; opacity: 0; visibility: hidden; transition: opacity 0.3s ease, visibility 0.3s ease; }
         .modal-overlay.visible { opacity: 1; visibility: visible; }
-        
+
         .modal-content { background: var(--modal-bg); color: var(--modal-text); padding: 1.5rem; border-radius: 0.5rem; width: 95%; box-shadow: 0 5px 15px rgba(0,0,0,0.3); transform: translateY(-20px); transition: transform 0.3s ease; display: flex; flex-direction: column; }
         .modal-overlay.visible .modal-content { transform: translateY(0); }
+
+        #icon-picker-modal { z-index: 1100; }
+        #icon-manager-modal, #char-manager-modal { z-index: 1110; }
         
         .notes-modal-content { max-width: 900px; height: 95vh; max-height: 95vh; padding: 0; }
 
@@ -222,6 +225,29 @@
     text-decoration: underline dotted;
     cursor: pointer;
     color: inherit;
+}
+/* Icono de nota en línea como superíndice; tamaño ajustable */
+.inline-note {
+    vertical-align: super;
+    font-size: var(--inline-note-size, 0.75em);
+    cursor: pointer;
+    color: inherit;
+}
+
+/* Tooltip para mostrar el contenido de la nota en línea */
+.inline-note-tooltip {
+    position: absolute;
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.375rem;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    max-width: 300px;
+    max-height: 80vh;
+    overflow: auto;
+    z-index: 1000;
+    pointer-events: auto;
 }
         /* Toolbar styles */
         .toolbar-separator {


### PR DESCRIPTION
## Summary
- add preset icons to emoji picker and use it for inline notes
- keep inline note tooltips open on hover and allow image zoom
- style inline note tooltips for interaction
- ensure icon picker and managers render above the note editor

## Testing
- `node --check index.js`
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a14221c3ac832c82c69ae0517b3dbd