### PR TITLE
feat: mejorar notas en línea

### DIFF
--- a/index.css
+++ b/index.css
@@ -223,9 +223,9 @@
     cursor: pointer;
     color: inherit;
 }
-/* Icono de nota en línea como subíndice */
+/* Icono de nota en línea como superíndice */
 .inline-note {
-    vertical-align: sub;
+    vertical-align: super;
     font-size: 0.8em;
     cursor: pointer;
     color: inherit;
@@ -242,7 +242,24 @@
     box-shadow: 0 2px 8px rgba(0,0,0,0.15);
     max-width: 300px;
     z-index: 1000;
-    pointer-events: none;
+    pointer-events: auto;
+}
+
+/* Selector de iconos para notas en línea */
+.icon-picker {
+    position: absolute;
+    display: flex;
+    gap: 4px;
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    padding: 4px;
+    border-radius: 0.25rem;
+    z-index: 1000;
+}
+
+.icon-picker span {
+    cursor: pointer;
+    font-size: 1rem;
 }
         /* Toolbar styles */
         .toolbar-separator {

--- a/index.html
+++ b/index.html
@@ -488,14 +488,18 @@
                     <!-- Lucide zoom-in icon -->
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-zoom-in"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/><line x1="11" x2="11" y1="8" y2="14"/><line x1="8" x2="14" y1="11" y2="11"/></svg>
                 </button>
-                <button id="zoom-out-lightbox-btn" class="p-2 bg-black/50 text-white rounded-full hover:bg-black/70" title="Alejar">
-                    <!-- Lucide zoom-out icon -->
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-zoom-out"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/><line x1="8" x2="14" y1="11" y2="11"/></svg>
-                </button>
-                <button id="download-lightbox-btn" class="p-2 bg-black/50 text-white rounded-full hover:bg-black/70" title="Descargar">
-                    <!-- Lucide download icon -->
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-download"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
-                </button>
+                 <button id="zoom-out-lightbox-btn" class="p-2 bg-black/50 text-white rounded-full hover:bg-black/70" title="Alejar">
+                      <!-- Lucide zoom-out icon -->
+                      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-zoom-out"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/><line x1="8" x2="14" y1="11" y2="11"/></svg>
+                  </button>
+                  <button id="fullscreen-lightbox-btn" class="p-2 bg-black/50 text-white rounded-full hover:bg-black/70" title="Pantalla completa">
+                      <!-- Lucide maximize-2 icon -->
+                      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-maximize-2"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg>
+                  </button>
+                  <button id="download-lightbox-btn" class="p-2 bg-black/50 text-white rounded-full hover:bg-black/70" title="Descargar">
+                      <!-- Lucide download icon -->
+                      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-download"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+                  </button>
             </div>
             <div class="relative max-w-[90vw] max-h-[85vh] overflow-auto">
                 <img id="lightbox-image" src="" alt="Vista de imagen" class="max-w-full max-h-full object-contain rounded-lg shadow-2xl transition-transform duration-200 ease-in-out">


### PR DESCRIPTION
## Summary
- Add toolbar button ℹ️ with preset icon picker for inline notes
- Render inline note icons as superscripts and keep tooltips interactive with image lightbox
- Enable fullscreen view in image lightbox

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a17b10f964832c9cf3ddb9a20b0c55