### PR TITLE
feat: improve inline note icons

### DIFF
--- a/index.css
+++ b/index.css
@@ -223,10 +223,10 @@
     cursor: pointer;
     color: inherit;
 }
-/* Icono de nota en línea como subíndice */
+/* Icono de nota en línea mostrado como superíndice con tamaño ajustable */
 .inline-note {
-    vertical-align: sub;
-    font-size: 0.8em;
+    vertical-align: super;
+    font-size: var(--inline-note-size, 0.8em);
     cursor: pointer;
     color: inherit;
 }
@@ -241,8 +241,8 @@
     border-radius: 0.375rem;
     box-shadow: 0 2px 8px rgba(0,0,0,0.15);
     max-width: 300px;
-    z-index: 1000;
-    pointer-events: none;
+    z-index: 2000;
+    pointer-events: auto;
 }
         /* Toolbar styles */
         .toolbar-separator {


### PR DESCRIPTION
## Summary
- add toolbar button ℹ️ with dropdown to pick note icons
- render inline note icons as superscripts with adjustable size
- keep inline note tooltips interactive and allow image lightbox on double click

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a17b10f964832c9cf3ddb9a20b0c55