### PR TITLE
feat: improve inline note tool

### DIFF
--- a/index.css
+++ b/index.css
@@ -224,9 +224,10 @@
     color: inherit;
 }
 /* Icono de nota en línea como subíndice */
+/* Icono de nota en línea */
 .inline-note {
-    vertical-align: sub;
-    font-size: 0.8em;
+    vertical-align: super;
+    font-size: var(--inline-note-size, 0.8em);
     cursor: pointer;
     color: inherit;
 }
@@ -241,8 +242,13 @@
     border-radius: 0.375rem;
     box-shadow: 0 2px 8px rgba(0,0,0,0.15);
     max-width: 300px;
-    z-index: 1000;
-    pointer-events: none;
+    z-index: 950;
+    pointer-events: auto;
+}
+
+.inline-note-tooltip img {
+    max-width: 100%;
+    height: auto;
 }
         /* Toolbar styles */
         .toolbar-separator {


### PR DESCRIPTION
## Summary
- add toolbar picker to insert inline notes with customizable icon and size
- keep note tooltips interactive and allow image preview in a dark modal with fullscreen support
- enable inline editing of image captions in the lightbox viewer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a17b10f964832c9cf3ddb9a20b0c55