### PR TITLE
feat: add side-by-side image support

### DIFF
--- a/index.css
+++ b/index.css
@@ -150,6 +150,14 @@
         #notes-editor:focus { outline: none; }
         #notes-editor img { max-width: 100%; height: auto; border-radius: 0.5rem; cursor: pointer; }
         #notes-editor img.selected-for-resize { outline: 2px solid var(--btn-primary-bg); }
+        #notes-editor .image-row {
+            display: flex;
+            gap: 0.5rem;
+        }
+        #notes-editor .image-row img {
+            flex: 1;
+            width: 100%;
+        }
 
         /* Style the sub-note editor similar to the main notes editor */
         #subnote-editor {
@@ -164,6 +172,14 @@
         #subnote-editor:focus { outline: none; }
         #subnote-editor img { max-width: 100%; height: auto; border-radius: 0.5rem; cursor: pointer; }
         #subnote-editor img.selected-for-resize { outline: 2px solid var(--btn-primary-bg); }
+        #subnote-editor .image-row {
+            display: flex;
+            gap: 0.5rem;
+        }
+        #subnote-editor .image-row img {
+            flex: 1;
+            width: 100%;
+        }
 
         /* Smaller buttons for the sub-note action bar */
         #subnote-modal-actions button {

--- a/index.js
+++ b/index.js
@@ -2194,6 +2194,17 @@ document.addEventListener('DOMContentLoaded', function () {
             notesEditor.focus();
         });
         editorToolbar.appendChild(floatImageBtn);
+
+        const sideBySideBtn = createButton('Insertar dos imágenes lado a lado', '🖼️🖼️', null, null, () => {
+            const url1 = prompt('URL de la primera imagen:');
+            if (!url1) return;
+            const url2 = prompt('URL de la segunda imagen:');
+            if (!url2) return;
+            const html = `<div class="image-row"><img src="${url1}"><img src="${url2}"></div>`;
+            document.execCommand('insertHTML', false, html);
+            saveState();
+        });
+        editorToolbar.appendChild(sideBySideBtn);
         
         const gallerySVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-gallery-horizontal-end w-5 h-5"><path d="M2 7v10"/><path d="M6 5v14"/><rect width="12" height="18" x="10" y="3" rx="2"/></svg>`;
         editorToolbar.appendChild(createButton('Crear Galería de Imágenes', gallerySVG, null, null, openGalleryLinkEditor));


### PR DESCRIPTION
## Summary
- allow inserting two images next to each other with a new toolbar button
- style `.image-row` containers so images share space and stay responsive

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a287eda034832ca487918f1789e1de