### PR TITLE
Improve tooltip interaction and allow resizing

### DIFF
--- a/index.css
+++ b/index.css
@@ -252,9 +252,12 @@
     padding: 0.25rem 0.5rem;
     border-radius: 0.375rem;
     box-shadow: 0 2px 8px rgba(0,0,0,0.15);
-    max-width: 300px;
+    max-width: 90vw;
+    max-height: 80vh;
     z-index: 2000;
     pointer-events: auto;
+    resize: both;
+    overflow: auto;
 }
         /* Toolbar styles */
         .toolbar-separator {


### PR DESCRIPTION
## Summary
- Add delay and spatial margin before hiding inline-note tooltips for easier interaction
- Make tooltip boxes resizable with mouse
- Ensure tooltip styling supports larger sizes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3a83c3e8c832c8cb5df3f20fdf58d