### PR TITLE
feat: add print grid styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,22 @@ This contains everything you need to run your app locally.
 ### Features
 
 - Nueva herramienta en el editor para redimensionar lateralmente notas o bloques HTML insertados mediante el botón ↔️ de la barra de herramientas.
+
+## Print layout
+
+To keep card grids aligned when printing to PDF, load `index.css` and wrap printable sections as follows:
+
+```html
+<div class="print-scale" style="--print-scale:0.9">
+  <div class="print-grid">
+    <!-- card elements here -->
+  </div>
+</div>
+```
+
+- The grid uses two fluid columns with a uniform gap and avoids fixed widths or negative margins.
+- `--print-scale` controls internal scaling so the browser print dialog can stay at 100%.
+- Add `data-paper="letter"` on the `<html>` element to switch to US Letter paper; otherwise A4 is used.
+- All cards use `page-break-inside: avoid` to stay on the same page.
+- Backgrounds and borders print with their original colors.
+

--- a/index.css
+++ b/index.css
@@ -804,3 +804,49 @@ table.resizable-table .table-resize-handle {
 .note-gray { background-color: #f3f4f6; border-color: #6b7280; }
 .note-shadow { box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
 .predef-note-btn { margin:0; cursor:pointer; }
+/* Print-friendly grid for cards */
+@page {
+    size: A4 portrait;
+    margin: 12mm;
+}
+@page letter {
+    size: 8.5in 11in;
+    margin: 12mm;
+}
+@media print {
+    /* Switch to letter size when data-paper="letter" is present on html */
+    html[data-paper="letter"] {
+        page: letter;
+    }
+
+    *, *::before, *::after {
+        -webkit-print-color-adjust: exact;
+        print-color-adjust: exact;
+    }
+
+    body {
+        margin: 0;
+    }
+
+    .print-scale {
+        /* Controlled internal scaling instead of print dialog zoom */
+        transform-origin: top left;
+        scale: var(--print-scale, 1);
+        width: calc(100% / var(--print-scale, 1));
+    }
+
+    .print-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: var(--print-card-gap, 8mm);
+    }
+    .print-grid > * {
+        page-break-inside: avoid;
+        break-inside: avoid;
+    }
+
+    textarea {
+        overflow: visible !important;
+        resize: none !important;
+    }
+}


### PR DESCRIPTION
## Summary
- add CSS rules for stable two-column print layout, including page sizing, controlled scaling, and color-safe output
- document how to use the new print helpers in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a52be7ad50832cad73e18614eefe67