### PR TITLE
feat: add HTML viewer for selected content

### DIFF
--- a/index.html
+++ b/index.html
@@ -432,6 +432,17 @@
         </div>
     </div>
 
+    <div id="selected-html-modal" class="modal-overlay">
+        <div class="modal-content w-full max-w-2xl">
+            <h3 class="text-xl font-bold mb-4">HTML del contenido seleccionado</h3>
+            <textarea id="selected-html-output" class="w-full h-40 p-2 mb-4 border border-border-color rounded-lg bg-secondary font-mono" readonly></textarea>
+            <div class="flex justify-end gap-2">
+                <button id="copy-selected-html-btn" class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">Copiar</button>
+                <button id="close-selected-html-btn" class="px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600">Cerrar</button>
+            </div>
+        </div>
+    </div>
+
     <div id="note-info-modal" class="modal-overlay">
         <div class="modal-content w-full max-w-sm">
             <h3 class="text-lg font-bold mb-4">Información de la Nota</h3>

--- a/index.js
+++ b/index.js
@@ -206,6 +206,11 @@ document.addEventListener('DOMContentLoaded', function () {
     const htmlFavoritesList = getElem('html-favorites-list');
     let currentHtmlEditor = null;
 
+    const selectedHtmlModal = getElem('selected-html-modal');
+    const selectedHtmlOutput = getElem('selected-html-output');
+    const copySelectedHtmlBtn = getElem('copy-selected-html-btn');
+    const closeSelectedHtmlBtn = getElem('close-selected-html-btn');
+
     // Table grid element
     const tableGridEl = getElem('table-grid');
 
@@ -751,6 +756,21 @@ document.addEventListener('DOMContentLoaded', function () {
             }
             currentHtmlEditor = subNoteEditor;
             openHtmlCodeModal();
+        }));
+
+        subNoteToolbar.appendChild(createSNButton('Ver HTML del seleccionado', '&lt;HTML&gt;', null, null, () => {
+            const selection = window.getSelection();
+            if (!selection || selection.rangeCount === 0) {
+                showAlert('No hay selección para mostrar.');
+                return;
+            }
+            const range = selection.getRangeAt(0);
+            const container = document.createElement('div');
+            container.appendChild(range.cloneContents());
+            selectedHtmlOutput.value = container.innerHTML;
+            currentHtmlEditor = subNoteEditor;
+            showModal(selectedHtmlModal);
+            setTimeout(() => selectedHtmlOutput.select(), 0);
         }));
 
         subNoteToolbar.appendChild(createSNSeparator());
@@ -2112,6 +2132,22 @@ document.addEventListener('DOMContentLoaded', function () {
         });
         editorToolbar.appendChild(htmlCodeBtn);
 
+        const viewHtmlBtn = createButton('Ver HTML del seleccionado', '&lt;HTML&gt;', null, null, () => {
+            const selection = window.getSelection();
+            if (!selection || selection.rangeCount === 0) {
+                showAlert('No hay selección para mostrar.');
+                return;
+            }
+            const range = selection.getRangeAt(0);
+            const container = document.createElement('div');
+            container.appendChild(range.cloneContents());
+            selectedHtmlOutput.value = container.innerHTML;
+            currentHtmlEditor = notesEditor;
+            showModal(selectedHtmlModal);
+            setTimeout(() => selectedHtmlOutput.select(), 0);
+        });
+        editorToolbar.appendChild(viewHtmlBtn);
+
         const enableLeftResize = (el) => {
             const threshold = 5;
             let resizing = false;
@@ -2746,6 +2782,17 @@ document.addEventListener('DOMContentLoaded', function () {
         hideModal(htmlCodeModal);
         if (currentHtmlEditor) currentHtmlEditor.focus();
         savedEditorSelection = null;
+    });
+
+    copySelectedHtmlBtn.addEventListener('click', () => {
+        navigator.clipboard.writeText(selectedHtmlOutput.value || '');
+        hideModal(selectedHtmlModal);
+        if (currentHtmlEditor) currentHtmlEditor.focus();
+    });
+
+    closeSelectedHtmlBtn.addEventListener('click', () => {
+        hideModal(selectedHtmlModal);
+        if (currentHtmlEditor) currentHtmlEditor.focus();
     });
 
     saveHtmlFavoriteBtn.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- add modal to display HTML for current selection with copy and close controls
- add toolbar buttons in notes and sub-notes to open the HTML viewer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a53c652a84832cb97d064802a2cd3a