### PR TITLE
feat: add image caption tool

### DIFF
--- a/index.css
+++ b/index.css
@@ -163,6 +163,16 @@
             height: auto;
         }
 
+        /* Caption below images */
+        #notes-editor .image-caption,
+        #print-area .image-caption {
+            display: block;
+            text-align: center;
+            font-size: 0.875rem;
+            color: var(--text-secondary);
+            margin-top: 0.25rem;
+        }
+
         /* Style the sub-note editor similar to the main notes editor */
         #subnote-editor {
             border: 1px solid var(--border-color);


### PR DESCRIPTION
## Summary
- add toolbar button to insert or edit captions below images
- show image captions in editor and print view
- sync lightbox caption edits with visible footnotes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a647e31310832c8e653f24528242d8