### PR TITLE
feat: añadir notas al pie de imágenes

### DIFF
--- a/index.css
+++ b/index.css
@@ -406,6 +406,14 @@ table.resizable-table .table-resize-handle {
     border-radius: 0.25rem;
 }
 
+/* Caption below images */
+.image-caption {
+    text-align: center;
+    font-size: 0.875rem;
+    color: var(--text-muted);
+    margin-top: 0.25rem;
+}
+
 /* Table size selection grid */
 #table-grid {
     display: grid;

--- a/index.js
+++ b/index.js
@@ -2299,6 +2299,61 @@ document.addEventListener('DOMContentLoaded', function () {
         });
         editorToolbar.appendChild(floatImageBtn);
 
+        const captionImageBtn = createButton('Añadir nota al pie de la imagen', '🖼️📝', null, null, () => {
+            let img = selectedImageForResize;
+            if (!img) {
+                const sel = window.getSelection();
+                if (sel && sel.rangeCount) {
+                    let node = sel.getRangeAt(0).startContainer;
+                    if (node.nodeType === Node.TEXT_NODE) node = node.parentNode;
+                    if (node.tagName === 'IMG') {
+                        img = node;
+                    } else if (node.querySelector) {
+                        const found = node.querySelector('img');
+                        if (found) img = found;
+                    }
+                }
+            }
+            if (!img) {
+                alertMessage.textContent = 'Selecciona primero una imagen para añadir la nota.';
+                alertTitle.textContent = 'Imagen no seleccionada';
+                showModal(alertModal);
+                return;
+            }
+            const newCaption = prompt('Nota al pie de la imagen:', img.dataset.caption || '');
+            if (newCaption === null) return;
+            const captionText = newCaption.trim();
+            if (!captionText) {
+                delete img.dataset.caption;
+                const fig = img.closest('figure');
+                const fc = fig ? fig.querySelector('figcaption') : null;
+                if (fc) fc.remove();
+                return;
+            }
+            img.dataset.caption = captionText;
+            let fig = img.closest('figure');
+            if (!fig) {
+                fig = document.createElement('figure');
+                fig.contentEditable = 'false';
+                img.parentNode.insertBefore(fig, img);
+                fig.appendChild(img);
+                const spacer = document.createTextNode('\u00A0');
+                fig.parentNode.insertBefore(spacer, fig.nextSibling);
+            }
+            let fc = fig.querySelector('figcaption');
+            if (!fc) {
+                fc = document.createElement('figcaption');
+                fc.className = 'image-caption';
+                fc.contentEditable = 'true';
+                fc.addEventListener('input', () => {
+                    img.dataset.caption = fc.textContent.trim();
+                });
+                fig.appendChild(fc);
+            }
+            fc.textContent = captionText;
+        });
+        editorToolbar.appendChild(captionImageBtn);
+
         const sideBySideBtn = createButton('Alinear imágenes en fila', '🖼️🖼️', null, null, wrapSelectedImagesSideBySide);
         editorToolbar.appendChild(sideBySideBtn);
 


### PR DESCRIPTION
## Summary
- Añade botón en la barra principal para insertar o editar notas al pie de las imágenes
- Estiliza los pies de foto para que se muestren centrados y visibles durante la edición e impresión

## Testing
- `npm test` *(falla: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a647e31310832c8e653f24528242d8