### PR TITLE
feat: add image caption tool

### DIFF
--- a/index.css
+++ b/index.css
@@ -151,16 +151,49 @@
         #notes-editor img { max-width: 100%; height: auto; border-radius: 0.5rem; cursor: pointer; }
         #notes-editor img.selected-for-resize { outline: 2px solid var(--btn-primary-bg); }
 
+        #notes-editor figure.image-with-caption,
+        #subnote-editor figure.image-with-caption,
+        #print-area figure.image-with-caption {
+            display: inline-block;
+            text-align: center;
+            margin: 1rem auto;
+        }
+        #notes-editor figure.image-with-caption img,
+        #subnote-editor figure.image-with-caption img,
+        #print-area figure.image-with-caption img {
+            display: block;
+            margin: 0 auto;
+            max-width: 100%;
+            height: auto;
+        }
+        #notes-editor figure.image-with-caption figcaption,
+        #subnote-editor figure.image-with-caption figcaption,
+        #print-area figure.image-with-caption figcaption {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-top: 0.25rem;
+        }
+
         /* Display multiple images in a row */
-        #notes-editor .image-row {
+        #notes-editor .image-row,
+        #subnote-editor .image-row {
             display: flex;
             gap: 0.5rem;
             flex-wrap: wrap;
         }
-        #notes-editor .image-row img {
+        #notes-editor .image-row > *,
+        #subnote-editor .image-row > * {
             flex: 1 1 0;
             max-width: 100%;
+        }
+        #notes-editor .image-row img,
+        #subnote-editor .image-row img {
+            max-width: 100%;
             height: auto;
+        }
+        #notes-editor .image-row figure,
+        #subnote-editor .image-row figure {
+            margin: 0;
         }
 
         /* Style the sub-note editor similar to the main notes editor */
@@ -763,6 +796,7 @@ table.resizable-table .table-resize-handle {
             }
             /* Ensure side-by-side images print in the same row */
             #notes-editor .image-row,
+            #subnote-editor .image-row,
             #print-area .image-row {
                 display: flex;
                 gap: 0.5rem;
@@ -770,11 +804,28 @@ table.resizable-table .table-resize-handle {
                 page-break-inside: avoid;
                 break-inside: avoid;
             }
-            #notes-editor .image-row img,
-            #print-area .image-row img {
+            #notes-editor .image-row > *,
+            #subnote-editor .image-row > *,
+            #print-area .image-row > * {
                 flex: 1 1 0;
                 max-width: 100%;
+            }
+            #notes-editor .image-row img,
+            #subnote-editor .image-row img,
+            #print-area .image-row img {
+                max-width: 100%;
                 height: auto;
+                page-break-inside: avoid;
+                break-inside: avoid;
+            }
+            #notes-editor .image-row figure,
+            #subnote-editor .image-row figure,
+            #print-area .image-row figure {
+                margin: 0;
+            }
+            #notes-editor figure.image-with-caption,
+            #subnote-editor figure.image-with-caption,
+            #print-area figure.image-with-caption {
                 page-break-inside: avoid;
                 break-inside: avoid;
             }

--- a/index.js
+++ b/index.js
@@ -787,6 +787,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 document.execCommand('insertImage', false, url);
             }
         }));
+        subNoteToolbar.appendChild(createSNButton('Agregar nota al pie de imagen', '📝', null, null, addCaptionToSelectedImage));
         // Gallery link insertion
         const gallerySVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-gallery-horizontal-end w-5 h-5"><path d="M2 7v10"/><path d="M6 5v14"/><rect width="12" height="18" x="10" y="3" rx="2"/></svg>`;
         subNoteToolbar.appendChild(createSNButton('Crear Galería de Imágenes', gallerySVG, null, null, () => {
@@ -2311,6 +2312,9 @@ document.addEventListener('DOMContentLoaded', function () {
         const resizeMinusBtn = createButton('Disminuir tamaño de imagen (-10%)', '➖', null, null, () => resizeSelectedImage(0.9));
         editorToolbar.appendChild(resizeMinusBtn);
 
+        const captionBtn = createButton('Agregar nota al pie de imagen', '📝', null, null, addCaptionToSelectedImage);
+        editorToolbar.appendChild(captionBtn);
+
         // Eliminamos el botón de inserción de tablas y el separador asociado
 
         // Print/Save
@@ -2437,6 +2441,67 @@ document.addEventListener('DOMContentLoaded', function () {
             selectedImageForResize.style.height = 'auto'; // Keep aspect ratio
         } else {
             showAlert("Por favor, selecciona una imagen primero para cambiar su tamaño.");
+        }
+    }
+
+    function addCaptionToSelectedImage() {
+        let img = selectedImageForResize;
+        if (!img) {
+            const sel = window.getSelection();
+            if (sel && sel.rangeCount > 0) {
+                let node = sel.getRangeAt(0).startContainer;
+                if (node.nodeType === Node.TEXT_NODE) node = node.parentNode;
+                if (node.tagName === 'IMG') {
+                    img = node;
+                } else if (node.querySelector) {
+                    const found = node.querySelector('img');
+                    if (found) img = found;
+                }
+            }
+        }
+        if (!img) {
+            showAlert("Por favor, selecciona una imagen para agregar una nota al pie.");
+            return;
+        }
+        const note = prompt('Nota al pie de la imagen:', img.dataset.caption || '');
+        if (note === null) return;
+        const captionText = note.trim();
+        if (captionText) {
+            let fig = img.closest('figure');
+            if (!fig) {
+                fig = document.createElement('figure');
+                fig.classList.add('image-with-caption');
+                fig.contentEditable = 'false';
+                img.parentNode.insertBefore(fig, img);
+                fig.appendChild(img);
+                const spacer = document.createTextNode('\u00A0');
+                fig.parentNode.insertBefore(spacer, fig.nextSibling);
+            } else {
+                fig.classList.add('image-with-caption');
+            }
+            img.dataset.caption = captionText;
+            let fc = fig.querySelector('figcaption');
+            if (!fc) {
+                fc = document.createElement('figcaption');
+                fig.appendChild(fc);
+            }
+            fc.textContent = captionText;
+        } else {
+            img.dataset.caption = '';
+            const fig = img.closest('figure');
+            if (fig) {
+                const fc = fig.querySelector('figcaption');
+                if (fc) fc.remove();
+                fig.classList.remove('image-with-caption');
+            }
+        }
+        if (notesEditor.contains(img)) {
+            notesEditor.focus();
+            if (currentNotesArray && currentNotesArray[activeNoteIndex]) {
+                saveCurrentNote();
+            }
+        } else if (subNoteEditor && subNoteEditor.contains(img)) {
+            subNoteEditor.focus();
         }
     }
 


### PR DESCRIPTION
## Summary
- add toolbar button to append image footnotes in main and sub-note editors
- implement helper to wrap selected image and manage caption text
- style figure captions for screen and print layouts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a647e31310832c8e653f24528242d8