### PR TITLE
feat: manage HTML templates

### DIFF
--- a/index.html
+++ b/index.html
@@ -424,10 +424,17 @@
                 <input id="html-favorite-name" type="text" placeholder="Nombre del favorito" class="flex-grow p-2 border border-border-color rounded-lg bg-secondary">
                 <button id="save-html-favorite-btn" class="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 text-sm">Guardar</button>
             </div>
-            <div id="html-favorites-list" class="flex flex-wrap gap-2 mb-4"></div>
-            <div class="flex justify-end gap-2">
-                <button id="cancel-html-btn" class="px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600">Cancelar</button>
-                <button id="insert-html-btn" class="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700">Insertar</button>
+            <div id="html-favorites-list" class="flex flex-col gap-2 mb-4"></div>
+            <div class="flex justify-between gap-2">
+                <div class="flex gap-2">
+                    <input type="file" id="import-html-favorites-input" class="hidden" accept="application/json">
+                    <button id="import-html-favorites-btn" class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm">Importar</button>
+                    <button id="export-html-favorites-btn" class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm">Exportar</button>
+                </div>
+                <div class="flex gap-2">
+                    <button id="cancel-html-btn" class="px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600">Cancelar</button>
+                    <button id="insert-html-btn" class="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700">Insertar</button>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add import/export of stored HTML snippets as templates
- allow renaming, editing, and deleting saved HTML templates

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a93cdb36bc832ca26195460b124e40