### PR TITLE
feat: add card-based template manager

### DIFF
--- a/templates.css
+++ b/templates.css
@@ -1,0 +1,7 @@
+#tag-scroll::-webkit-scrollbar { height: 6px; }
+#tag-scroll::-webkit-scrollbar-thumb { background: #cbd5e1; border-radius: 3px; }
+.template-card { position: relative; }
+.template-actions { display: none; position: absolute; top: 4px; right: 4px; gap: 4px; }
+.template-card.editing .template-actions,
+.template-card:hover .template-actions { display: flex; }
+.favorite { color: #fbbf24; }

--- a/templates.html
+++ b/templates.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="es" data-theme="default">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gestor de Planillas</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="templates.css" />
+</head>
+<body class="bg-gray-50 text-gray-800">
+  <header class="flex items-center justify-between p-4 bg-white shadow">
+    <div class="flex items-center gap-2">
+      <input id="search" type="text" placeholder="Buscar" class="border rounded px-2 py-1" />
+      <select id="sort" class="border rounded px-2 py-1">
+        <option value="newest">Más nuevas</option>
+        <option value="az">A-Z</option>
+      </select>
+      <button id="edit-toggle" class="px-3 py-1 bg-blue-600 text-white rounded">Editar</button>
+    </div>
+    <div class="flex items-center gap-2">
+      <button id="save-btn" class="px-3 py-1 bg-green-600 text-white rounded">Guardar</button>
+      <button id="import-btn" class="px-3 py-1 bg-sky-600 text-white rounded">Importar</button>
+      <input type="file" id="import-file" accept=".json" class="hidden" />
+      <button id="export-btn" class="px-3 py-1 bg-purple-600 text-white rounded">Exportar</button>
+    </div>
+  </header>
+
+  <section class="p-4">
+    <div id="tag-scroll" class="flex items-center gap-2 overflow-x-auto pb-2 mb-4"></div>
+    <div id="templates-container" class="h-[60vh] overflow-y-auto">
+      <div id="templates-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
+    </div>
+    <div class="flex justify-between items-center mt-4">
+      <button id="prev-page" class="px-2 py-1 border rounded">Anterior</button>
+      <span id="page-info" class="text-sm"></span>
+      <button id="next-page" class="px-2 py-1 border rounded">Siguiente</button>
+    </div>
+  </section>
+
+  <div id="toast" class="hidden fixed bottom-4 left-1/2 transform -translate-x-1/2 bg-gray-800 text-white px-4 py-2 rounded shadow"></div>
+
+  <script type="module" src="templates.js"></script>
+</body>
+</html>

--- a/templates.js
+++ b/templates.js
@@ -1,0 +1,156 @@
+const templates = JSON.parse(localStorage.getItem('templates') || '[]');
+let editMode = false;
+let currentTag = null;
+let currentSearch = '';
+let sortMode = 'newest';
+let currentPage = 1;
+const pageSize = 12;
+let deletedTemplate = null;
+
+const searchInput = document.getElementById('search');
+const sortSelect = document.getElementById('sort');
+const editToggle = document.getElementById('edit-toggle');
+const grid = document.getElementById('templates-grid');
+const tagScroll = document.getElementById('tag-scroll');
+const prevBtn = document.getElementById('prev-page');
+const nextBtn = document.getElementById('next-page');
+const pageInfo = document.getElementById('page-info');
+const toast = document.getElementById('toast');
+
+function save() {
+  localStorage.setItem('templates', JSON.stringify(templates));
+}
+
+function uniqueTags() {
+  const set = new Set();
+  templates.forEach(t => t.tags?.forEach(tag => set.add(tag)));
+  return Array.from(set);
+}
+
+function renderTags() {
+  tagScroll.innerHTML = '';
+  uniqueTags().forEach(tag => {
+    const chip = document.createElement('button');
+    chip.textContent = tag;
+    chip.className = 'px-2 py-1 rounded-full border whitespace-nowrap' + (currentTag===tag? ' bg-blue-100' : '');
+    chip.addEventListener('click', () => {
+      currentTag = currentTag === tag ? null : tag;
+      currentPage = 1;
+      render();
+    });
+    tagScroll.appendChild(chip);
+  });
+}
+
+function render() {
+  renderTags();
+  let items = templates.slice();
+  if (currentSearch) {
+    items = items.filter(t => t.title.toLowerCase().includes(currentSearch));
+  }
+  if (currentTag) {
+    items = items.filter(t => t.tags?.includes(currentTag));
+  }
+  items.sort((a,b)=>{
+    if(a.favorite&&!b.favorite) return -1;
+    if(!a.favorite&&b.favorite) return 1;
+    if (sortMode==='az') return a.title.localeCompare(b.title);
+    return b.created - a.created;
+  });
+  const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
+  currentPage = Math.min(currentPage, totalPages);
+  const start = (currentPage-1)*pageSize;
+  const pageItems = items.slice(start, start+pageSize);
+  grid.innerHTML = '';
+  pageItems.forEach(t => {
+    const card = document.createElement('div');
+    card.className = 'template-card border rounded p-3 bg-white shadow';
+    if(editMode) card.classList.add('editing');
+    const fav = document.createElement('button');
+    fav.innerHTML = '⭐';
+    if(t.favorite) fav.classList.add('favorite');
+    fav.addEventListener('click',()=>{t.favorite=!t.favorite;save();render();});
+    const actions = document.createElement('div');
+    actions.className = 'template-actions';
+    const editBtn = document.createElement('button');
+    editBtn.textContent = '✏️';
+    editBtn.addEventListener('click',()=>{/* editar */});
+    const delBtn = document.createElement('button');
+    delBtn.textContent = '🗑';
+    delBtn.addEventListener('click',()=>del(t.id));
+    actions.append(editBtn, delBtn);
+    const title = document.createElement('h3');
+    title.className='font-semibold mb-2 flex justify-between';
+    title.append(document.createTextNode(t.title), fav);
+    const preview = document.createElement('div');
+    preview.className='text-sm text-gray-600';
+    preview.innerHTML = t.content.slice(0,80) + '...';
+    card.append(actions,title,preview);
+    grid.appendChild(card);
+  });
+  pageInfo.textContent = `Página ${currentPage} de ${totalPages}`;
+  prevBtn.disabled = currentPage===1;
+  nextBtn.disabled = currentPage===totalPages;
+}
+
+function del(id){
+  const idx = templates.findIndex(t=>t.id===id);
+  if(idx>-1){
+    deletedTemplate = {item: templates[idx], index: idx};
+    templates.splice(idx,1);
+    save();
+    render();
+    showToast('Eliminada ✓ <button id="undo" class="underline ml-2">Deshacer</button>');
+    document.getElementById('undo').addEventListener('click',()=>{
+      templates.splice(deletedTemplate.index,0,deletedTemplate.item);
+      save();
+      hideToast();
+      render();
+    });
+    setTimeout(()=>{deletedTemplate=null;hideToast();},5000);
+  }
+}
+
+function showToast(html){
+  toast.innerHTML = html;
+  toast.classList.remove('hidden');
+}
+function hideToast(){
+  toast.classList.add('hidden');
+}
+
+searchInput.addEventListener('input',()=>{currentSearch=searchInput.value.toLowerCase();currentPage=1;render();});
+sortSelect.addEventListener('change',()=>{sortMode=sortSelect.value;render();});
+editToggle.addEventListener('click',()=>{editMode=!editMode;editToggle.classList.toggle('bg-blue-800');render();});
+prevBtn.addEventListener('click',()=>{if(currentPage>1){currentPage--;render();}});
+nextBtn.addEventListener('click',()=>{currentPage++;render();});
+
+document.getElementById('export-btn').addEventListener('click',()=>{
+  const blob = new Blob([JSON.stringify(templates)],{type:'application/json'});
+  const a = document.createElement('a');
+  a.href=URL.createObjectURL(blob);
+  a.download='templates.json';
+  a.click();
+});
+
+const importInput = document.getElementById('import-file');
+importInput.addEventListener('change',e=>{
+  const file=e.target.files[0];
+  if(!file) return;
+  const reader=new FileReader();
+  reader.onload=ev=>{
+    try{const data=JSON.parse(ev.target.result);if(Array.isArray(data)){templates.splice(0,templates.length,...data);save();render();}}
+    catch(err){console.error(err);}
+  };
+  reader.readAsText(file);
+});
+document.getElementById('import-btn').addEventListener('click',()=>importInput.click());
+document.getElementById('save-btn').addEventListener('click',save);
+
+// populate example data if empty
+if(templates.length===0){
+  templates.push({id:1,title:'Ejemplo',content:'<p>Contenido de ejemplo</p>',tags:['demo'],favorite:false,created:Date.now()});
+  save();
+}
+
+render();


### PR DESCRIPTION
## Summary
- add separate template manager with card grid and pagination
- support search, sorting, tag filters, and favorites
- allow import/export, edit toggles, and undoable deletions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a945bd013c832c9e487fcc87176d4f