### PR TITLE
Include patient data in export and support decimal drug doses

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,23 @@
     <div class="max-w-7xl mx-auto bg-secondary rounded-xl shadow-lg overflow-hidden my-8">
         <div class="p-6 sm:p-8">
             <h1 class="text-2xl sm:text-3xl font-bold text-primary mb-4 text-center">Temario para Examen Final de Medicina Interna</h1>
+            <div class="flex flex-col md:flex-row gap-2 mb-4">
+                <input id="patient-name" type="text" placeholder="Nombre del paciente" class="flex-1 border rounded p-2" />
+                <input id="patient-rut" type="text" placeholder="RUT del paciente" class="flex-1 border rounded p-2" />
+            </div>
+            <div class="my-4 space-y-2">
+                <div class="flex gap-2">
+                    <input id="drug-name" type="text" placeholder="Fármaco" class="flex-1 border rounded p-2" />
+                    <input id="drug-dose" type="text" placeholder="Dosis (mg/día)" class="w-40 border rounded p-2" />
+                    <button id="add-drug-btn" class="px-3 py-2 bg-blue-600 text-white rounded">Añadir</button>
+                </div>
+                <table class="min-w-full border border-gray-300 text-sm">
+                    <thead>
+                        <tr><th class="border px-2">Fármaco</th><th class="border px-2">Dosis (mg/día)</th></tr>
+                    </thead>
+                    <tbody id="drugs-table-body"></tbody>
+                </table>
+            </div>
             <div class="flex flex-col md:flex-row flex-wrap items-center justify-between gap-4 my-4">
                  <button id="ask-ai-btn" class="w-full md:w-auto order-1 px-6 py-2 bg-indigo-600 text-white font-semibold rounded-lg shadow-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-opacity-75 flex items-center justify-center space-x-2">
                     <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path d="M10 2a.75.75 0 01.75.75v.518a3.75 3.75 0 013.232 4.025l-1.82 1.82a.75.75 0 101.06 1.06l1.82-1.82A5.25 5.25 0 0010.75 2.52V2.75A.75.75 0 0110 2zM3.483 4.49A5.23 5.23 0 002.5 7.25v.518a3.75 3.75 0 014.025-3.232l-1.82-1.82a.75.75 0 10-1.06 1.06l1.82 1.82zM10 18a.75.75 0 01-.75-.75v-.518a3.75 3.75 0 01-3.232-4.025l1.82-1.82a.75.75 0 10-1.06-1.06l-1.82 1.82A5.25 5.25 0 009.25 17.48v.77a.75.75 0 01.75.75zM16.517 15.51a5.23 5.23 0 00.983-2.76v-.518a3.75 3.75 0 01-4.025 3.232l1.82 1.82a.75.75 0 101.06-1.06l-1.82-1.82zM10 12a2 2 0 100-4 2 2 0 000 4z"/></svg>

--- a/index.js
+++ b/index.js
@@ -227,11 +227,19 @@ document.addEventListener('DOMContentLoaded', function () {
     let undoTimer = null;
     let deletedFavorite = null;
     let htmlFavorites = [];
+    let drugs = [];
 
     const selectedHtmlModal = getElem('selected-html-modal');
     const selectedHtmlOutput = getElem('selected-html-output');
     const copySelectedHtmlBtn = getElem('copy-selected-html-btn');
     const closeSelectedHtmlBtn = getElem('close-selected-html-btn');
+
+    const patientNameInput = getElem('patient-name');
+    const patientRutInput = getElem('patient-rut');
+    const drugNameInput = getElem('drug-name');
+    const drugDoseInput = getElem('drug-dose');
+    const addDrugBtn = getElem('add-drug-btn');
+    const drugsTableBody = getElem('drugs-table-body');
 
     // Table grid element
     const tableGridEl = getElem('table-grid');
@@ -285,6 +293,33 @@ document.addEventListener('DOMContentLoaded', function () {
             insertTableWithDimensions(rows, cols);
         });
     }
+
+    function renderDrugsTable() {
+        if (!drugsTableBody) return;
+        drugsTableBody.innerHTML = '';
+        drugs.forEach(d => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td class="border px-2">${d.name}</td><td class="border px-2">${d.dose}</td>`;
+            drugsTableBody.appendChild(tr);
+        });
+    }
+
+    addDrugBtn?.addEventListener('click', () => {
+        const name = drugNameInput.value.trim();
+        const doseStr = drugDoseInput.value.trim();
+        // parseFloat permite dosis decimales como 0.6 mg/día
+        const dose = parseFloat(doseStr.replace(',', '.'));
+        if (!name || isNaN(dose)) return;
+        drugs.push({ name, dose: doseStr });
+        drugNameInput.value = '';
+        drugDoseInput.value = '';
+        renderDrugsTable();
+        saveState();
+    });
+
+    [patientNameInput, patientRutInput].forEach(el => {
+        el?.addEventListener('input', () => saveState());
+    });
 
     // --- Customizable Icon and Character Lists ---
     // These variables will be initialized later, after EMOJI_CATEGORIES is
@@ -2547,7 +2582,12 @@ document.addEventListener('DOMContentLoaded', function () {
                 theme: document.documentElement.dataset.theme,
                 iconStyle: document.documentElement.dataset.iconStyle,
             },
-            headers: {}
+            headers: {},
+            patient: {
+                name: patientNameInput?.value || '',
+                rut: patientRutInput?.value || ''
+            },
+            drugs: [...drugs]
         };
 
         document.querySelectorAll('thead th[contenteditable="true"]').forEach((th, i) => {
@@ -2591,6 +2631,16 @@ document.addEventListener('DOMContentLoaded', function () {
             document.querySelectorAll('thead th[contenteditable="true"]').forEach((th, i) => {
                 if(state.headers[`h${i}`]) th.innerText = state.headers[`h${i}`];
             });
+        }
+
+        if (state.patient) {
+            if (patientNameInput) patientNameInput.value = state.patient.name || '';
+            if (patientRutInput) patientRutInput.value = state.patient.rut || '';
+        }
+
+        if (state.drugs) {
+            drugs = state.drugs;
+            renderDrugsTable();
         }
         
         if (state.topics) {
@@ -2664,6 +2714,8 @@ document.addEventListener('DOMContentLoaded', function () {
             
             const settingsPromise = db.set('keyvalue', { key: 'settings', value: state.settings });
             const headersPromise = db.set('keyvalue', { key: 'headers', value: state.headers });
+            const patientPromise = db.set('keyvalue', { key: 'patient', value: state.patient });
+            const drugsPromise = db.set('keyvalue', { key: 'drugs', value: state.drugs });
 
             const topicPromises = Object.entries(state.topics).map(([topicId, data]) => 
                 db.set('topics', { id: topicId, ...data })
@@ -2672,7 +2724,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 db.set('sections', { id: sectionId, ...data })
             );
 
-            await Promise.all([settingsPromise, headersPromise, ...topicPromises, ...sectionPromises]);
+            await Promise.all([settingsPromise, headersPromise, patientPromise, drugsPromise, ...topicPromises, ...sectionPromises]);
 
             showSaveConfirmation();
 
@@ -2692,6 +2744,8 @@ document.addEventListener('DOMContentLoaded', function () {
             const sections = await db.getAll('sections');
             const settingsData = await db.get('keyvalue', 'settings');
             const headersData = await db.get('keyvalue', 'headers');
+            const patientData = await db.get('keyvalue', 'patient');
+            const drugsData = await db.get('keyvalue', 'drugs');
 
             const state = {
                 topics: topics.reduce((acc, topic) => {
@@ -2703,7 +2757,9 @@ document.addEventListener('DOMContentLoaded', function () {
                     return acc;
                 }, {}),
                 settings: settingsData ? settingsData.value : {},
-                headers: headersData ? headersData.value : {}
+                headers: headersData ? headersData.value : {},
+                patient: patientData ? patientData.value : {},
+                drugs: drugsData ? drugsData.value : []
             };
             
             _loadStateFromObject(state);


### PR DESCRIPTION
## Summary
- Add patient name and RUT fields and export them along with drug list
- Persist patient info and medications to IndexedDB
- Parse drug doses as floats so 0.6 mg/day is accepted

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a95351dbec832c86aceebd55bf9abd