### PR TITLE
fix: preserve tooltip notes and unify tooltip position

### DIFF
--- a/index.css
+++ b/index.css
@@ -254,7 +254,9 @@
 
 /* Tooltip para mostrar el contenido de la nota en línea */
 .inline-note-tooltip {
-    position: absolute;
+    position: fixed;
+    top: 20px;
+    left: 20px;
     background-color: var(--bg-secondary);
     color: var(--text-primary);
     border: 1px solid var(--border-color);

--- a/index.js
+++ b/index.js
@@ -3334,11 +3334,25 @@ document.addEventListener('DOMContentLoaded', function () {
         // Keep existing postits and quick note data
         const existingPostits = currentNotesArray[activeNoteIndex].postits || {};
         const existingQuickNote = currentNotesArray[activeNoteIndex].quickNote || '';
+
+        // Build an updated set of postits based on icons present in the editor
+        const updatedPostits = {};
+        notesEditor.querySelectorAll('.inline-note').forEach(icon => {
+            const id = icon.dataset.subnoteId || icon.dataset.postitId;
+            if (!id) return;
+            if (existingPostits[id]) {
+                updatedPostits[id] = existingPostits[id];
+            } else {
+                // Ensure newly added icons have an associated placeholder entry
+                updatedPostits[id] = { title: '', content: '' };
+            }
+        });
+
         currentNotesArray[activeNoteIndex] = {
             title: currentTitle,
             content: currentContent,
             lastEdited: new Date().toISOString(),
-            postits: existingPostits,
+            postits: updatedPostits,
             quickNote: existingQuickNote
         };
 
@@ -3638,9 +3652,9 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         });
         document.body.appendChild(tooltip);
-        const rect = icon.getBoundingClientRect();
-        tooltip.style.top = `${rect.bottom + window.scrollY + 4}px`;
-        tooltip.style.left = `${rect.left + window.scrollX}px`;
+        // Display tooltip from a fixed location in the viewport
+        tooltip.style.top = '20px';
+        tooltip.style.left = '20px';
         icon._tooltip = tooltip;
     }
 


### PR DESCRIPTION
## Summary
- ensure inline note tooltips are stored when saving a note
- show tooltips at a consistent top-left location

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab88cc8880832c840cf11781429a42