### PR TITLE
Fix paste & spacing issues; add note tabs and minimize option

### DIFF
--- a/index.css
+++ b/index.css
@@ -101,6 +101,7 @@
         
         .modal-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.5); display: flex; align-items: center; justify-content: center; z-index: 1000; opacity: 0; visibility: hidden; transition: opacity 0.3s ease, visibility 0.3s ease; }
         .modal-overlay.visible { opacity: 1; visibility: visible; }
+        #html-code-modal { z-index: 1100; }
         
         .modal-content { background: var(--modal-bg); color: var(--modal-text); padding: 1.5rem; border-radius: 0.5rem; width: 95%; box-shadow: 0 5px 15px rgba(0,0,0,0.3); transform: translateY(-20px); transition: transform 0.3s ease; display: flex; flex-direction: column; }
         .modal-overlay.visible .modal-content { transform: translateY(0); }
@@ -218,6 +219,11 @@
         }
         
         .progress-ring-circle { transition: stroke-dashoffset 0.5s ease-out; }
+
+        .notes-tabs { display: flex; gap: 0.25rem; border-bottom: 1px solid var(--border-color); overflow-x: auto; }
+        .notes-tabs .note-tab { padding: 0.25rem 0.5rem; border: 1px solid var(--border-color); border-bottom: none; background-color: var(--bg-secondary); border-top-left-radius: 0.25rem; border-top-right-radius: 0.25rem; cursor: pointer; white-space: nowrap; }
+        .notes-tabs .note-tab.active { background-color: var(--bg-tertiary); }
+        .notes-minimized-btn { position: fixed; bottom: 1rem; right: 1rem; background-color: var(--btn-primary-bg); color: var(--btn-primary-text); border-radius: 0.375rem; padding: 0.5rem; z-index: 2000; }
         
         #icon-picker-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(40px, 1fr)); gap: 1rem; max-height: 300px; overflow-y: auto; padding: 1rem 0; }
         .icon-picker-item { cursor: pointer; padding: 8px; border-radius: 8px; transition: background-color 0.2s; }

--- a/index.html
+++ b/index.html
@@ -340,9 +340,11 @@
                           <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
                         </svg>
                     </button>
+                    <div id="notes-tabs" class="notes-tabs flex-shrink-0 pl-10"></div>
                      <div class="flex justify-between items-center mb-4 flex-shrink-0 pl-10">
                         <h3 id="notes-modal-title" class="text-xl font-bold text-primary truncate" contenteditable="true"></h3>
                         <div class="flex items-center gap-1">
+                            <button id="minimize-note-btn" class="toolbar-btn" title="Minimizar">🗕</button>
                             <button id="note-info-btn" class="toolbar-btn" title="Información de la nota">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-info w-5 h-5"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
                             </button>
@@ -381,7 +383,9 @@
             </div>
         </div>
     </div>
-    
+
+    <button id="restore-note-btn" class="notes-minimized-btn hidden" title="Restaurar nota">📝</button>
+
     <div id="ai-qa-modal" class="modal-overlay">
         <div class="modal-content w-full max-w-2xl">
             <h3 class="text-xl font-bold mb-4">Preguntar a la IA</h3>


### PR DESCRIPTION
## Summary
- Fix clipboard paste so characters insert without extra newlines
- Improve line spacing controls and add +/- buttons
- Raise HTML code modal z-index, add note tabs and minimize/restore controls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae1803427c832c9312afcdfb7da460