### PR TITLE
Eliminar límite en tablas y permitir edición de iconos/caracteres

### DIFF
--- a/index.css
+++ b/index.css
@@ -219,7 +219,7 @@
         
         .progress-ring-circle { transition: stroke-dashoffset 0.5s ease-out; }
         
-        #icon-picker-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(40px, 1fr)); gap: 1rem; max-height: 300px; overflow-y: auto; padding: 1rem 0; }
+        #icon-picker-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(40px, 1fr)); gap: 1rem; padding: 1rem 0; }
         .icon-picker-item { cursor: pointer; padding: 8px; border-radius: 8px; transition: background-color 0.2s; }
         .icon-picker-item:hover { background-color: var(--bg-tertiary); }
         .icon-picker-item svg { width: 32px; height: 32px; margin: auto; }
@@ -327,7 +327,7 @@
         .color-submenu.visible { display: grid; }
 
         .symbol-dropdown { position: relative; display: inline-block; }
-        .symbol-dropdown-content { display: none; position: absolute; left: 100%; top: 0; background-color: var(--bg-secondary); min-width: 280px; max-height: 200px; overflow-y: auto; box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2); z-index: 10; border-radius: 8px; border: 1px solid var(--border-color); padding: 8px; grid-template-columns: repeat(auto-fill, minmax(32px, 1fr)); gap: 4px; }
+        .symbol-dropdown-content { display: none; position: absolute; left: 100%; top: 0; background-color: var(--bg-secondary); min-width: 280px; box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2); z-index: 10; border-radius: 8px; border: 1px solid var(--border-color); padding: 8px; grid-template-columns: repeat(auto-fill, minmax(32px, 1fr)); gap: 4px; }
         .symbol-dropdown-content.visible { display: grid; }
         .symbol-btn {
             font-size: 18px;

--- a/index.html
+++ b/index.html
@@ -287,7 +287,7 @@
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-settings"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.67 1.67 0 0 0 0-3M4.6 9a1.67 1.67 0 0 0 0 3"/><path d="M15 4.6a1.67 1.67 0 0 0-3 0M9 19.4a1.67 1.67 0 0 0 3 0"/><path d="M19.4 9a1.67 1.67 0 0 0 0-3M4.6 15a1.67 1.67 0 0 0 0 3"/><path d="M9 4.6a1.67 1.67 0 0 0 3 0M15 19.4a1.67 1.67 0 0 0-3 0"/></svg>
                 </button>
             </div>
-            <div id="emoji-grid" class="max-h-80 overflow-y-auto">
+            <div id="emoji-grid">
                 <!-- Emoji grid will be populated by JS -->
             </div>
         </div>

--- a/index.js
+++ b/index.js
@@ -694,6 +694,18 @@ document.addEventListener('DOMContentLoaded', function () {
                     });
                     content.appendChild(sBtn);
                 });
+
+                // Botón para administrar caracteres
+                const manageBtn = document.createElement('button');
+                manageBtn.textContent = 'Editar';
+                manageBtn.className = 'toolbar-btn';
+                manageBtn.style.gridColumn = '1 / -1';
+                manageBtn.addEventListener('click', () => {
+                    renderCharManager();
+                    showModal(charManagerModal);
+                    content.classList.remove('visible');
+                });
+                content.appendChild(manageBtn);
             };
             renderSNSyms();
             dropdown.appendChild(content);
@@ -2051,6 +2063,18 @@ document.addEventListener('DOMContentLoaded', function () {
                     });
                     content.appendChild(symBtn);
                 });
+
+                // Botón para administrar caracteres
+                const manageBtn = document.createElement('button');
+                manageBtn.textContent = 'Editar';
+                manageBtn.className = 'toolbar-btn';
+                manageBtn.style.gridColumn = '1 / -1';
+                manageBtn.addEventListener('click', () => {
+                    renderCharManager();
+                    showModal(charManagerModal);
+                    content.classList.remove('visible');
+                });
+                content.appendChild(manageBtn);
             };
             renderSymbols();
             dropdown.appendChild(content);


### PR DESCRIPTION
## Resumen
- Quitar restricciones de alto para que los listados de iconos y caracteres no se corten al desplegarse.
- Añadir un botón **Editar** en los desplegables de símbolos para abrir el administrador de caracteres.

## Pruebas
- `npm test` *(falla: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae8920c87c832c86c47b0f20d59b95