### PR TITLE
Allow full icon and character grids and add edit buttons

### DIFF
--- a/index.css
+++ b/index.css
@@ -327,7 +327,7 @@
         .color-submenu.visible { display: grid; }
 
         .symbol-dropdown { position: relative; display: inline-block; }
-        .symbol-dropdown-content { display: none; position: absolute; left: 100%; top: 0; background-color: var(--bg-secondary); min-width: 280px; max-height: 200px; overflow-y: auto; box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2); z-index: 10; border-radius: 8px; border: 1px solid var(--border-color); padding: 8px; grid-template-columns: repeat(auto-fill, minmax(32px, 1fr)); gap: 4px; }
+        .symbol-dropdown-content { display: none; position: absolute; left: 100%; top: 0; background-color: var(--bg-secondary); min-width: 280px; box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2); z-index: 10; border-radius: 8px; border: 1px solid var(--border-color); padding: 8px; grid-template-columns: repeat(auto-fill, minmax(32px, 1fr)); gap: 4px; }
         .symbol-dropdown-content.visible { display: grid; }
         .symbol-btn {
             font-size: 18px;

--- a/index.html
+++ b/index.html
@@ -287,7 +287,8 @@
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-settings"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.67 1.67 0 0 0 0-3M4.6 9a1.67 1.67 0 0 0 0 3"/><path d="M15 4.6a1.67 1.67 0 0 0-3 0M9 19.4a1.67 1.67 0 0 0 3 0"/><path d="M19.4 9a1.67 1.67 0 0 0 0-3M4.6 15a1.67 1.67 0 0 0 0 3"/><path d="M9 4.6a1.67 1.67 0 0 0 3 0M15 19.4a1.67 1.67 0 0 0-3 0"/></svg>
                 </button>
             </div>
-            <div id="emoji-grid" class="max-h-80 overflow-y-auto">
+            <button id="edit-icons-btn" class="mb-4 px-3 py-1 bg-blue-600 text-white rounded-lg hover:bg-blue-700">Editar iconos</button>
+            <div id="emoji-grid">
                 <!-- Emoji grid will be populated by JS -->
             </div>
         </div>

--- a/index.js
+++ b/index.js
@@ -175,6 +175,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const iconPickerModal = getElem('icon-picker-modal');
     const iconPickerCategories = getElem('icon-picker-categories');
     const emojiGrid = getElem('emoji-grid');
+    const editIconsBtn = getElem('edit-icons-btn');
     const cancelIconPickerBtn = getElem('cancel-icon-picker-btn');
 
     // Custom icon input elements
@@ -1206,13 +1207,17 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     // Open icon manager modal
+    const openIconManager = () => {
+        // Ensure the combined list includes custom icons appended to the default
+        EMOJI_CATEGORIES['Sugeridos'] = defaultSuggestedIcons.concat(customIconsList);
+        renderIconManager();
+        showModal(iconManagerModal);
+    };
     if (openIconManagerBtn) {
-        openIconManagerBtn.addEventListener('click', () => {
-            // Ensure the combined list includes custom icons appended to the default
-            EMOJI_CATEGORIES['Sugeridos'] = defaultSuggestedIcons.concat(customIconsList);
-            renderIconManager();
-            showModal(iconManagerModal);
-        });
+        openIconManagerBtn.addEventListener('click', openIconManager);
+    }
+    if (editIconsBtn) {
+        editIconsBtn.addEventListener('click', openIconManager);
     }
     // Close icon manager modal
     if (closeIconManagerBtn) {
@@ -2051,6 +2056,17 @@ document.addEventListener('DOMContentLoaded', function () {
                     });
                     content.appendChild(symBtn);
                 });
+                const editCharsBtn = document.createElement('button');
+                editCharsBtn.className = 'symbol-btn';
+                editCharsBtn.textContent = '✏️';
+                editCharsBtn.title = 'Editar caracteres';
+                editCharsBtn.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    renderCharManager();
+                    showModal(charManagerModal);
+                });
+                content.appendChild(editCharsBtn);
             };
             renderSymbols();
             dropdown.appendChild(content);


### PR DESCRIPTION
## Summary
- Remove height limits from icon picker grid and character dropdown.
- Add explicit edit buttons for icons and characters to open their management modals.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ae8920c87c832c86c47b0f20d59b95