### PR TITLE
fix: initialize subnote toolbar after emoji categories

### DIFF
--- a/index.css
+++ b/index.css
@@ -99,8 +99,8 @@
         
         thead th { position: sticky; top: 0; z-index: 20; background-color: var(--header-bg); color: var(--header-text); }
         
-        .modal-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.5); display: flex; align-items: center; justify-content: center; z-index: 1000; opacity: 0; visibility: hidden; transition: opacity 0.3s ease, visibility 0.3s ease; }
-        .modal-overlay.visible { opacity: 1; visibility: visible; }
+        .modal-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.5); display: flex; align-items: center; justify-content: center; z-index: 1000; opacity: 0; visibility: hidden; pointer-events: none; transition: opacity 0.3s ease, visibility 0.3s ease; }
+        .modal-overlay.visible { opacity: 1; visibility: visible; pointer-events: auto; }
         
         .modal-content { background: var(--modal-bg); color: var(--modal-text); padding: 1.5rem; border-radius: 0.5rem; width: 95%; box-shadow: 0 5px 15px rgba(0,0,0,0.3); transform: translateY(-20px); transition: transform 0.3s ease; display: flex; flex-direction: column; }
         .modal-overlay.visible .modal-content { transform: translateY(0); }
@@ -219,7 +219,8 @@
         
         .progress-ring-circle { transition: stroke-dashoffset 0.5s ease-out; }
         
-        #icon-picker-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(40px, 1fr)); gap: 1rem; max-height: 300px; overflow-y: auto; padding: 1rem 0; }
+        #icon-picker-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(40px, 1fr)); gap: 1rem; padding: 1rem 0; }
+        #emoji-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(40px, 1fr)); gap: 1rem; padding: 1rem 0; max-height: none; overflow: visible; }
         .icon-picker-item { cursor: pointer; padding: 8px; border-radius: 8px; transition: background-color 0.2s; }
         .icon-picker-item:hover { background-color: var(--bg-tertiary); }
         .icon-picker-item svg { width: 32px; height: 32px; margin: auto; }
@@ -327,12 +328,21 @@
         .color-submenu.visible { display: grid; }
 
         .symbol-dropdown { position: relative; display: inline-block; }
-        .symbol-dropdown-content { display: none; position: absolute; left: 100%; top: 0; background-color: var(--bg-secondary); min-width: 280px; max-height: 200px; overflow-y: auto; box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2); z-index: 10; border-radius: 8px; border: 1px solid var(--border-color); padding: 8px; grid-template-columns: repeat(auto-fill, minmax(32px, 1fr)); gap: 4px; }
+        .symbol-dropdown-content { display: none; position: absolute; right: 100%; top: 0; margin-right: 8px; background-color: var(--bg-secondary); min-width: 280px; box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2); z-index: 1010; border-radius: 8px; border: 1px solid var(--border-color); padding: 8px; grid-template-columns: repeat(auto-fill, minmax(32px, 1fr)); gap: 4px; max-height: none; overflow: visible; }
         .symbol-dropdown-content.visible { display: grid; }
         .symbol-btn {
             font-size: 18px;
             text-align: center;
             font-family: "Segoe UI Emoji", "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Symbol", sans-serif;
+        }
+
+        .symbol-edit-btn {
+            grid-column: 1 / -1;
+            margin-top: 4px;
+            padding: 4px 8px;
+            font-size: 14px;
+            background-color: var(--bg-tertiary);
+            border-radius: 4px;
         }
 
         .symbol-dropdown-content.flex-dropdown.visible {

--- a/index.html
+++ b/index.html
@@ -287,7 +287,7 @@
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-settings"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.67 1.67 0 0 0 0-3M4.6 9a1.67 1.67 0 0 0 0 3"/><path d="M15 4.6a1.67 1.67 0 0 0-3 0M9 19.4a1.67 1.67 0 0 0 3 0"/><path d="M19.4 9a1.67 1.67 0 0 0 0-3M4.6 15a1.67 1.67 0 0 0 0 3"/><path d="M9 4.6a1.67 1.67 0 0 0 3 0M15 19.4a1.67 1.67 0 0 0-3 0"/></svg>
                 </button>
             </div>
-            <div id="emoji-grid" class="max-h-80 overflow-y-auto">
+            <div id="emoji-grid">
                 <!-- Emoji grid will be populated by JS -->
             </div>
         </div>

--- a/index.js
+++ b/index.js
@@ -674,7 +674,7 @@ document.addEventListener('DOMContentLoaded', function () {
             return group;
         };
 
-        const createSNSymbolDropdown = (symbols, title, icon) => {
+        const createSNSymbolDropdown = (symbols, title, icon, managerCallback) => {
             const dropdown = document.createElement('div');
             dropdown.className = 'symbol-dropdown';
             const btn = document.createElement('button');
@@ -694,6 +694,16 @@ document.addEventListener('DOMContentLoaded', function () {
                     });
                     content.appendChild(sBtn);
                 });
+                if (managerCallback) {
+                    const manageBtn = document.createElement('button');
+                    manageBtn.className = 'symbol-edit-btn toolbar-btn';
+                    manageBtn.textContent = 'Editar';
+                    manageBtn.addEventListener('click', () => {
+                        content.classList.remove('visible');
+                        managerCallback();
+                    });
+                    content.appendChild(manageBtn);
+                }
             };
             renderSNSyms();
             dropdown.appendChild(content);
@@ -703,6 +713,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 document.querySelectorAll('.color-submenu.visible, .symbol-dropdown-content.visible').forEach(d => {
                     if (d !== content) d.classList.remove('visible');
                 });
+                renderSNSyms();
                 content.classList.toggle('visible');
             });
             return dropdown;
@@ -961,10 +972,15 @@ document.addEventListener('DOMContentLoaded', function () {
 
         subNoteToolbar.appendChild(createSNSeparator());
         // Symbols and special characters
-        const symbols = ["💡", "⚠️", "📌", "📍", "✴️", "🟢", "🟡", "🔴", "✅", "☑️", "❌", "➡️", "⬅️", "➔", "👉", "↳", "▪️", "▫️", "🔵", "🔹", "🔸", "➕", "➖", "📂", "📄", "📝", "📋", "📎", "🔑", "📈", "📉", "🩺", "💉", "💊", "🩸", "🧪", "🔬", "🩻", "🦠"];
-        subNoteToolbar.appendChild(createSNSymbolDropdown(symbols, 'Insertar Símbolo', '📌'));
-        const specialChars = ['∞','±','≈','•','‣','↑','↓','→','←','↔','⇧','⇩','⇨','⇦','↗','↘','↙','↖'];
-        subNoteToolbar.appendChild(createSNSymbolDropdown(specialChars, 'Caracteres Especiales', 'Ω'));
+        subNoteToolbar.appendChild(createSNSymbolDropdown(EMOJI_CATEGORIES['Sugeridos'], 'Insertar Símbolo', '📌', () => {
+            EMOJI_CATEGORIES['Sugeridos'] = defaultSuggestedIcons.concat(customIconsList);
+            renderIconManager();
+            showModal(iconManagerModal);
+        }));
+        subNoteToolbar.appendChild(createSNSymbolDropdown(globalSpecialChars, 'Caracteres Especiales', 'Ω', () => {
+            renderCharManager();
+            showModal(charManagerModal);
+        }));
         // Image from URL
         subNoteToolbar.appendChild(createSNButton('Insertar Imagen desde URL', '🖼️', null, null, () => {
             const url = prompt('Ingresa la URL de la imagen:');
@@ -1004,9 +1020,6 @@ document.addEventListener('DOMContentLoaded', function () {
             window.print();
         }));
     }
-    // Initialize sub-note toolbar on load
-    setupSubnoteToolbar();
-
     // Save and close sub-note
     if (saveCloseSubnoteBtn) {
         saveCloseSubnoteBtn.addEventListener('click', () => {
@@ -1019,8 +1032,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     title: subNoteTitle.textContent.trim(),
                     content: subNoteEditor.innerHTML
                 };
-                // Persist changes to note
-                saveCurrentNote();
+                // Note will be saved when the main note is saved
             }
             hideModal(subNoteModal);
             activeSubnoteLink = null;
@@ -1039,7 +1051,6 @@ document.addEventListener('DOMContentLoaded', function () {
                     title: subNoteTitle.textContent.trim(),
                     content: subNoteEditor.innerHTML
                 };
-                saveCurrentNote();
             }
             // Do not close the modal, keep editing
         });
@@ -1241,17 +1252,6 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 
-    // Open character manager modal when user clicks the char manager gear.
-    // Currently there is no dedicated open button in the UI; you can create
-    // one if desired.  For demonstration purposes, we bind it to the icon
-    // manager open button when the user holds Shift.
-    if (openIconManagerBtn && charManagerModal) {
-        openIconManagerBtn.addEventListener('dblclick', (e) => {
-            e.preventDefault();
-            renderCharManager();
-            showModal(charManagerModal);
-        });
-    }
     if (closeCharManagerBtn) {
         closeCharManagerBtn.addEventListener('click', () => hideModal(charManagerModal));
     }
@@ -1721,7 +1721,10 @@ document.addEventListener('DOMContentLoaded', function () {
     defaultSuggestedIcons = Array.isArray(EMOJI_CATEGORIES['Sugeridos']) ? [...EMOJI_CATEGORIES['Sugeridos']] : [];
     customIconsList = [];
     globalSpecialChars = ['∞','±','≈','•','‣','↑','↓','→','←','↔','⇧','⇩','⇨','⇦','↗','↘','↙','↖'];
-    
+
+    // Initialize sub-note toolbar on load
+    setupSubnoteToolbar();
+
     // --- Core Logic Functions ---
 
     function formatBytes(bytes, decimals = 2) {
@@ -2028,7 +2031,7 @@ document.addEventListener('DOMContentLoaded', function () {
             return group;
         };
 
-        const createSymbolDropdown = (symbols, title, icon) => {
+        const createSymbolDropdown = (symbols, title, icon, managerCallback) => {
             const dropdown = document.createElement('div');
             dropdown.className = 'symbol-dropdown';
             const btn = document.createElement('button');
@@ -2051,6 +2054,16 @@ document.addEventListener('DOMContentLoaded', function () {
                     });
                     content.appendChild(symBtn);
                 });
+                if (managerCallback) {
+                    const manageBtn = document.createElement('button');
+                    manageBtn.className = 'symbol-edit-btn toolbar-btn';
+                    manageBtn.textContent = 'Editar';
+                    manageBtn.addEventListener('click', () => {
+                        content.classList.remove('visible');
+                        managerCallback();
+                    });
+                    content.appendChild(manageBtn);
+                }
             };
             renderSymbols();
             dropdown.appendChild(content);
@@ -2061,6 +2074,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 otherOpen.forEach(d => {
                     if (d !== content) d.classList.remove('visible');
                 });
+                renderSymbols();
                 content.classList.toggle('visible');
             });
             return dropdown;
@@ -2528,11 +2542,16 @@ document.addEventListener('DOMContentLoaded', function () {
         editorToolbar.appendChild(createSeparator());
 
         // Symbols
-        const symbols = ["💡", "⚠️", "📌", "📍", "✴️", "🟢", "🟡", "🔴", "✅", "☑️", "❌", "➡️", "⬅️", "➔", "👉", "↳", "▪️", "▫️", "🔵", "🔹", "🔸", "➕", "➖", "📂", "📄", "📝", "📋", "📎", "🔑", "📈", "📉", "🩺", "💉", "💊", "🩸", "🧪", "🔬", "🩻", "🦠"];
-        editorToolbar.appendChild(createSymbolDropdown(symbols, 'Insertar Símbolo', '📌'));
+        editorToolbar.appendChild(createSymbolDropdown(EMOJI_CATEGORIES['Sugeridos'], 'Insertar Símbolo', '📌', () => {
+            EMOJI_CATEGORIES['Sugeridos'] = defaultSuggestedIcons.concat(customIconsList);
+            renderIconManager();
+            showModal(iconManagerModal);
+        }));
 
-        const specialChars = ['∞','±','≈','•','‣','↑','↓','→','←','↔','⇧','⇩','⇨','⇦','↗','↘','↙','↖'];
-        editorToolbar.appendChild(createSymbolDropdown(specialChars, 'Caracteres Especiales', 'Ω'));
+        editorToolbar.appendChild(createSymbolDropdown(globalSpecialChars, 'Caracteres Especiales', 'Ω', () => {
+            renderCharManager();
+            showModal(charManagerModal);
+        }));
     }
 
     function rgbToHex(rgb) {
@@ -3636,7 +3655,7 @@ document.addEventListener('DOMContentLoaded', function () {
     function loadNoteIntoEditor(index) {
         if (index < 0 || index >= currentNotesArray.length) {
             if (currentNotesArray.length === 0) {
-               addNewNote(false);
+               addNewNote();
                return;
             }
             index = 0; // fallback to the first note
@@ -3657,11 +3676,7 @@ document.addEventListener('DOMContentLoaded', function () {
         updateNoteInfo();
     }
     
-    function addNewNote(shouldSaveCurrent = true) {
-        if (shouldSaveCurrent) {
-            saveCurrentNote();
-        }
-        
+    function addNewNote() {
         const newIndex = currentNotesArray.length;
         currentNotesArray.push({
             title: `Nota ${newIndex + 1}`,
@@ -3688,7 +3703,7 @@ document.addEventListener('DOMContentLoaded', function () {
         }
 
         if (currentNotesArray.length === 0) {
-            addNewNote(false);
+            addNewNote();
         } else {
             loadNoteIntoEditor(newIndexToShow);
         }
@@ -3738,7 +3753,6 @@ document.addEventListener('DOMContentLoaded', function () {
         if (!activeTabId) return;
         const tab = openNoteTabs.find(t => t.id === activeTabId);
         if (!tab) return;
-        saveCurrentNote();
         tab.notesArray = currentNotesArray;
         tab.activeIndex = activeNoteIndex;
     }
@@ -3815,7 +3829,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 currentNotesArray[activeNoteIndex].postits = {};
             }
             currentNotesArray[activeNoteIndex].postits[uniqueId] = { title: '', content: '' };
-            saveCurrentNote();
         }
     }
 
@@ -3843,7 +3856,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 currentNotesArray[activeNoteIndex].postits = {};
             }
             currentNotesArray[activeNoteIndex].postits[uniqueId] = { title: '', content: '' };
-            saveCurrentNote();
         }
     }
 
@@ -4610,7 +4622,7 @@ document.addEventListener('DOMContentLoaded', function () {
             notesPanelToggle.classList.toggle('open');
         });
         
-        addNotePanelBtn.addEventListener('click', () => addNewNote(true));
+        addNotePanelBtn.addEventListener('click', () => addNewNote());
         notesList.addEventListener('click', (e) => {
             const itemBtn = e.target.closest('.note-item-btn');
             const deleteBtn = e.target.closest('.delete-note-btn');
@@ -4620,7 +4632,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 const index = parseInt(deleteBtn.dataset.index, 10);
                 deleteNote(index);
             } else if (itemBtn) {
-                saveCurrentNote(); // Save current before switching
                 const index = parseInt(itemBtn.dataset.index, 10);
                 loadNoteIntoEditor(index);
             }
@@ -4891,7 +4902,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 currentNotesArray[activeNoteIndex].quickNote = postitNoteTextarea.value;
                 hideModal(postitNoteModal);
                 editingQuickNote = false;
-                saveCurrentNote();
                 return;
             }
         });
@@ -4904,7 +4914,6 @@ document.addEventListener('DOMContentLoaded', function () {
                     currentNotesArray[activeNoteIndex].quickNote = '';
                     hideModal(postitNoteModal);
                     editingQuickNote = false;
-                    saveCurrentNote();
                 }
             }
         });
@@ -4987,14 +4996,8 @@ document.addEventListener('DOMContentLoaded', function () {
                 updateLightboxView();
                 if (activeGalleryLinkForLightbox) {
                     activeGalleryLinkForLightbox.dataset.images = JSON.stringify(lightboxImages);
-                    if (currentNotesArray && currentNotesArray[activeNoteIndex]) {
-                        saveCurrentNote();
-                    }
                 } else if (imgObj.element) {
                     imgObj.element.dataset.caption = imgObj.caption;
-                    if (currentNotesArray && currentNotesArray[activeNoteIndex]) {
-                        saveCurrentNote();
-                    }
                 }
             });
         }
@@ -5006,17 +5009,10 @@ document.addEventListener('DOMContentLoaded', function () {
                 if (imgObj) {
                     imgObj.caption = '';
                     updateLightboxView();
-                    // Persist the updated images data back to the link and save note
                     if (activeGalleryLinkForLightbox) {
                         activeGalleryLinkForLightbox.dataset.images = JSON.stringify(lightboxImages);
-                        if (currentNotesArray && currentNotesArray[activeNoteIndex]) {
-                            saveCurrentNote();
-                        }
                     } else if (imgObj.element) {
                         imgObj.element.dataset.caption = '';
-                        if (currentNotesArray && currentNotesArray[activeNoteIndex]) {
-                            saveCurrentNote();
-                        }
                     }
                 }
             });
@@ -5323,8 +5319,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 }
             });
         });
-
-        window.addEventListener('beforeunload', saveState);
 
     }
 


### PR DESCRIPTION
## Summary
- prevent reference error by initializing sub-note toolbar after defining EMOJI_CATEGORIES

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae8920c87c832c86c47b0f20d59b95