### PR TITLE
feat: allow image pasting in editors

### DIFF
--- a/index.js
+++ b/index.js
@@ -485,14 +485,30 @@ document.addEventListener('DOMContentLoaded', function () {
     [notesEditor, subNoteEditor].forEach(editor => {
         if (editor) {
             editor.addEventListener('paste', (e) => {
-                e.preventDefault();
                 const clipboard = e.clipboardData || window.clipboardData;
-                const html = clipboard.getData('text/html');
-                if (htmlPasteEnabled && html) {
-                    document.execCommand('insertHTML', false, sanitizeHtml(html));
+                const items = clipboard.items;
+                const imageItems = items ? Array.from(items).filter(item => item.type && item.type.startsWith('image/')) : [];
+                if (imageItems.length > 0) {
+                    e.preventDefault();
+                    imageItems.forEach(item => {
+                        const file = item.getAsFile();
+                        if (file) {
+                            const reader = new FileReader();
+                            reader.onload = (evt) => {
+                                document.execCommand('insertImage', false, evt.target.result);
+                            };
+                            reader.readAsDataURL(file);
+                        }
+                    });
                 } else {
-                    const text = clipboard.getData('text/plain');
-                    document.execCommand('insertText', false, text);
+                    e.preventDefault();
+                    const html = clipboard.getData('text/html');
+                    if (htmlPasteEnabled && html) {
+                        document.execCommand('insertHTML', false, sanitizeHtml(html));
+                    } else {
+                        const text = clipboard.getData('text/plain');
+                        document.execCommand('insertText', false, text);
+                    }
                 }
             });
         }


### PR DESCRIPTION
## Summary
- allow pasting images directly into note and subnote editors

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af781de110832c8836dcd7d1003e9f