### PR TITLE
Corrige esquinas de tablas y desborde de barra de herramientas

### DIFF
--- a/index.css
+++ b/index.css
@@ -151,9 +151,11 @@
             border-top-left-radius: 0.5rem;
             border-top-right-radius: 0.5rem;
             display: flex;
-            flex-wrap: wrap; 
+            flex-wrap: wrap;
             align-items: center;
             gap: 1px;
+            overflow-x: auto;
+            width: 100%;
         }
         #notes-editor { border: 1px solid var(--border-color); padding: 12px; flex-grow: 1; overflow-y: auto; border-bottom-left-radius: 0.5rem; border-bottom-right-radius: 0.5rem; line-height: 1.6; background-color: var(--bg-secondary); }
         #notes-editor:focus { outline: none; }

--- a/index.js
+++ b/index.js
@@ -904,6 +904,7 @@ document.addEventListener('DOMContentLoaded', function () {
             }
             elements.forEach((block, index) => {
                 if (block && subNoteEditor.contains(block)) {
+                    const isTableEl = ['TABLE', 'TR', 'TD', 'TH'].includes(block.tagName);
                     if (color === 'transparent') {
                         block.style.backgroundColor = '';
                         block.style.paddingLeft = '';
@@ -914,14 +915,23 @@ document.addEventListener('DOMContentLoaded', function () {
                         block.style.borderBottomRightRadius = '';
                     } else {
                         block.style.backgroundColor = color;
-                        block.style.paddingLeft = '6px';
-                        block.style.paddingRight = '6px';
-                        const first = index === 0;
-                        const last = index === elements.length - 1;
-                        block.style.borderTopLeftRadius = first ? '6px' : '0';
-                        block.style.borderTopRightRadius = first ? '6px' : '0';
-                        block.style.borderBottomLeftRadius = last ? '6px' : '0';
-                        block.style.borderBottomRightRadius = last ? '6px' : '0';
+                        if (!isTableEl) {
+                            block.style.paddingLeft = '6px';
+                            block.style.paddingRight = '6px';
+                            const first = index === 0;
+                            const last = index === elements.length - 1;
+                            block.style.borderTopLeftRadius = first ? '6px' : '0';
+                            block.style.borderTopRightRadius = first ? '6px' : '0';
+                            block.style.borderBottomLeftRadius = last ? '6px' : '0';
+                            block.style.borderBottomRightRadius = last ? '6px' : '0';
+                        } else {
+                            block.style.paddingLeft = '';
+                            block.style.paddingRight = '';
+                            block.style.borderTopLeftRadius = '0';
+                            block.style.borderTopRightRadius = '0';
+                            block.style.borderBottomLeftRadius = '0';
+                            block.style.borderBottomRightRadius = '0';
+                        }
                     }
                 }
             });
@@ -2206,6 +2216,7 @@ document.addEventListener('DOMContentLoaded', function () {
             }
             elements.forEach((block, index) => {
                 if (block && notesEditor.contains(block)) {
+                    const isTableEl = ['TABLE', 'TR', 'TD', 'TH'].includes(block.tagName);
                     if (color === 'transparent') {
                         // Remove highlight and reset borders and margins on clear
                         block.style.backgroundColor = '';
@@ -2219,18 +2230,29 @@ document.addEventListener('DOMContentLoaded', function () {
                         block.style.borderBottomRightRadius = '';
                     } else {
                         block.style.backgroundColor = color;
-                        block.style.paddingLeft = '6px';
-                        block.style.paddingRight = '6px';
-                        // Remove default margins to fuse adjacent highlighted lines
-                        block.style.marginTop = '0px';
-                        block.style.marginBottom = '0px';
-                        // Set border radius based on position in selection
-                        const first = index === 0;
-                        const last = index === elements.length - 1;
-                        block.style.borderTopLeftRadius = first ? '6px' : '0';
-                        block.style.borderTopRightRadius = first ? '6px' : '0';
-                        block.style.borderBottomLeftRadius = last ? '6px' : '0';
-                        block.style.borderBottomRightRadius = last ? '6px' : '0';
+                        if (!isTableEl) {
+                            block.style.paddingLeft = '6px';
+                            block.style.paddingRight = '6px';
+                            // Remove default margins to fuse adjacent highlighted lines
+                            block.style.marginTop = '0px';
+                            block.style.marginBottom = '0px';
+                            // Set border radius based on position in selection
+                            const first = index === 0;
+                            const last = index === elements.length - 1;
+                            block.style.borderTopLeftRadius = first ? '6px' : '0';
+                            block.style.borderTopRightRadius = first ? '6px' : '0';
+                            block.style.borderBottomLeftRadius = last ? '6px' : '0';
+                            block.style.borderBottomRightRadius = last ? '6px' : '0';
+                        } else {
+                            block.style.paddingLeft = '';
+                            block.style.paddingRight = '';
+                            block.style.marginTop = '';
+                            block.style.marginBottom = '';
+                            block.style.borderTopLeftRadius = '0';
+                            block.style.borderTopRightRadius = '0';
+                            block.style.borderBottomLeftRadius = '0';
+                            block.style.borderBottomRightRadius = '0';
+                        }
                     }
                 }
             });
@@ -4749,12 +4771,13 @@ document.addEventListener('DOMContentLoaded', function () {
                      }
                  }
                  subNoteTitle.textContent = subnoteData.title || '';
-                 subNoteEditor.innerHTML = subnoteData.content || '<p><br></p>';
-                 const modalContent = subNoteModal.querySelector('.notes-modal-content');
-                 modalContent.classList.remove('readonly-mode');
-                 subNoteEditor.contentEditable = true;
-                 subNoteTitle.contentEditable = true;
-                 subNoteEditor.focus();
+                subNoteEditor.innerHTML = subnoteData.content || '<p><br></p>';
+                subNoteEditor.querySelectorAll('table').forEach(initTableResize);
+                const modalContent = subNoteModal.querySelector('.notes-modal-content');
+                modalContent.classList.remove('readonly-mode');
+                subNoteEditor.contentEditable = true;
+                subNoteTitle.contentEditable = true;
+                subNoteEditor.focus();
                  showModal(subNoteModal);
                  return;
              }
@@ -4781,6 +4804,7 @@ document.addEventListener('DOMContentLoaded', function () {
                  // Populate sub-note modal fields
                 subNoteTitle.textContent = subnoteData.title || '';
                 subNoteEditor.innerHTML = subnoteData.content || '<p><br></p>';
+                subNoteEditor.querySelectorAll('table').forEach(initTableResize);
                 const modalContent = subNoteModal.querySelector('.notes-modal-content');
                 modalContent.classList.add('readonly-mode');
                 subNoteEditor.contentEditable = false;


### PR DESCRIPTION
## Resumen
- Evita que el resaltado de línea redondee bordes en tablas, manteniéndolos rectos.
- Permite redimensionar tablas de subnotas, habilitando el asa en la esquina y divisores internos.
- Agrega desplazamiento horizontal a la barra de herramientas para que los iconos no queden recortados.

## Pruebas
- `npm test` *(falla: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afcbcf88a0832ca35836fd576c5f79