### PR TITLE
Fix table highlight radius and toolbar overflow; improve table editing

### DIFF
--- a/index.css
+++ b/index.css
@@ -151,9 +151,14 @@
             border-top-left-radius: 0.5rem;
             border-top-right-radius: 0.5rem;
             display: flex;
-            flex-wrap: wrap; 
+            flex-wrap: nowrap;
             align-items: center;
             gap: 1px;
+            overflow-x: auto;
+        }
+
+        .editor-toolbar::-webkit-scrollbar {
+            height: 6px;
         }
         #notes-editor { border: 1px solid var(--border-color); padding: 12px; flex-grow: 1; overflow-y: auto; border-bottom-left-radius: 0.5rem; border-bottom-right-radius: 0.5rem; line-height: 1.6; background-color: var(--bg-secondary); }
         #notes-editor:focus { outline: none; }
@@ -385,12 +390,12 @@ table.resizable-table th {
 
 table.resizable-table .table-resize-handle {
     position: absolute;
-    width: 8px;
-    height: 8px;
+    width: 12px;
+    height: 12px;
     right: 0;
     bottom: 0;
     cursor: se-resize;
-    background: transparent;
+    background: var(--bg-secondary);
     border-right: 2px solid var(--text-muted);
     border-bottom: 2px solid var(--text-muted);
     opacity: 0.7;

--- a/index.js
+++ b/index.js
@@ -1636,6 +1636,7 @@ document.addEventListener('DOMContentLoaded', function () {
             }
             // After inserting, re-add resizers and controls
             initTableResize(table);
+            enableTableEditing(table);
             removeTableControls();
         });
         document.body.appendChild(insertRowBtn);
@@ -1655,6 +1656,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 newCell.style.padding = '4px';
             });
             initTableResize(table);
+            enableTableEditing(table);
             removeTableControls();
         });
         document.body.appendChild(insertColBtn);
@@ -1668,6 +1670,8 @@ document.addEventListener('DOMContentLoaded', function () {
         deleteRowBtn.style.top = `${cellRect.top - 16 + window.scrollY}px`;
         deleteRowBtn.addEventListener('click', () => {
             table.deleteRow(rowIndex);
+            initTableResize(table);
+            enableTableEditing(table);
             removeTableControls();
         });
         document.body.appendChild(deleteRowBtn);
@@ -1686,6 +1690,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 }
             });
             initTableResize(table);
+            enableTableEditing(table);
             removeTableControls();
         });
         document.body.appendChild(deleteColBtn);
@@ -2219,18 +2224,30 @@ document.addEventListener('DOMContentLoaded', function () {
                         block.style.borderBottomRightRadius = '';
                     } else {
                         block.style.backgroundColor = color;
-                        block.style.paddingLeft = '6px';
-                        block.style.paddingRight = '6px';
-                        // Remove default margins to fuse adjacent highlighted lines
-                        block.style.marginTop = '0px';
-                        block.style.marginBottom = '0px';
-                        // Set border radius based on position in selection
-                        const first = index === 0;
-                        const last = index === elements.length - 1;
-                        block.style.borderTopLeftRadius = first ? '6px' : '0';
-                        block.style.borderTopRightRadius = first ? '6px' : '0';
-                        block.style.borderBottomLeftRadius = last ? '6px' : '0';
-                        block.style.borderBottomRightRadius = last ? '6px' : '0';
+                        if (!block.closest('table')) {
+                            block.style.paddingLeft = '6px';
+                            block.style.paddingRight = '6px';
+                            // Remove default margins to fuse adjacent highlighted lines
+                            block.style.marginTop = '0px';
+                            block.style.marginBottom = '0px';
+                            // Set border radius based on position in selection
+                            const first = index === 0;
+                            const last = index === elements.length - 1;
+                            block.style.borderTopLeftRadius = first ? '6px' : '0';
+                            block.style.borderTopRightRadius = first ? '6px' : '0';
+                            block.style.borderBottomLeftRadius = last ? '6px' : '0';
+                            block.style.borderBottomRightRadius = last ? '6px' : '0';
+                        } else {
+                            // For table elements, avoid rounded corners and extra padding/margins
+                            block.style.paddingLeft = '';
+                            block.style.paddingRight = '';
+                            block.style.marginTop = '';
+                            block.style.marginBottom = '';
+                            block.style.borderTopLeftRadius = '0';
+                            block.style.borderTopRightRadius = '0';
+                            block.style.borderBottomLeftRadius = '0';
+                            block.style.borderBottomRightRadius = '0';
+                        }
                     }
                 }
             });
@@ -3601,7 +3618,7 @@ document.addEventListener('DOMContentLoaded', function () {
         // initialize resizers on newly inserted tables (defer to allow DOM insertion)
         setTimeout(() => {
             const tables = notesEditor.querySelectorAll('table');
-            tables.forEach(t => initTableResize(t));
+            tables.forEach(t => { initTableResize(t); enableTableEditing(t); });
         }, 50);
     }
     function initTableResize(table) {
@@ -3666,7 +3683,7 @@ document.addEventListener('DOMContentLoaded', function () {
         
         notesModalTitle.textContent = note.title || `Nota ${index + 1}`;
         notesEditor.innerHTML = note.content || '<p><br></p>';
-        notesEditor.querySelectorAll('table').forEach(initTableResize);
+        notesEditor.querySelectorAll('table').forEach(t => { initTableResize(t); enableTableEditing(t); });
 
         renderNotesList();
         notesEditor.focus();
@@ -4684,7 +4701,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     const reader = new FileReader();
                     reader.onload = (e) => {
                         notesEditor.innerHTML = e.target.result;
-                        notesEditor.querySelectorAll('table').forEach(initTableResize);
+                        notesEditor.querySelectorAll('table').forEach(t => { initTableResize(t); enableTableEditing(t); });
                     };
                     reader.readAsText(file);
                 }
@@ -5351,7 +5368,7 @@ document.addEventListener('DOMContentLoaded', function () {
         populateIconPicker();
         loadState();
         setupEventListeners();
-        document.querySelectorAll('table').forEach(initTableResize);
+        document.querySelectorAll('table').forEach(t => { initTableResize(t); enableTableEditing(t); });
         applyTheme(document.documentElement.dataset.theme || 'default');
         setupAdvancedSearchReplace();
         setupKeyboardShortcuts();


### PR DESCRIPTION
## Summary
- Ensure line highlight colors don't round table cell corners
- Allow scrolling in the toolbar so all icons remain visible
- Initialize table resizing and editing controls for existing tables

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afcbcf88a0832ca35836fd576c5f79