### PR TITLE
fix table highlight and toolbar overflow

### DIFF
--- a/index.css
+++ b/index.css
@@ -105,7 +105,7 @@
         .modal-content { background: var(--modal-bg); color: var(--modal-text); padding: 1.5rem; border-radius: 0.5rem; width: 95%; box-shadow: 0 5px 15px rgba(0,0,0,0.3); transform: translateY(-20px); transition: transform 0.3s ease; display: flex; flex-direction: column; }
         .modal-overlay.visible .modal-content { transform: translateY(0); }
         
-        .notes-modal-content { max-width: 900px; height: 95vh; max-height: 95vh; padding: 0; }
+        .notes-modal-content { max-width: 900px; height: 95vh; max-height: 95vh; padding: 0; overflow: visible; }
 
         #subnote-modal .notes-modal-content {
             padding: 1rem;
@@ -151,9 +151,10 @@
             border-top-left-radius: 0.5rem;
             border-top-right-radius: 0.5rem;
             display: flex;
-            flex-wrap: wrap; 
+            flex-wrap: wrap;
             align-items: center;
             gap: 1px;
+            overflow: visible;
         }
         #notes-editor { border: 1px solid var(--border-color); padding: 12px; flex-grow: 1; overflow-y: auto; border-bottom-left-radius: 0.5rem; border-bottom-right-radius: 0.5rem; line-height: 1.6; background-color: var(--bg-secondary); }
         #notes-editor:focus { outline: none; }
@@ -385,12 +386,12 @@ table.resizable-table th {
 
 table.resizable-table .table-resize-handle {
     position: absolute;
-    width: 8px;
-    height: 8px;
+    width: 12px;
+    height: 12px;
     right: 0;
     bottom: 0;
     cursor: se-resize;
-    background: transparent;
+    background: var(--bg-secondary);
     border-right: 2px solid var(--text-muted);
     border-bottom: 2px solid var(--text-muted);
     opacity: 0.7;

--- a/index.js
+++ b/index.js
@@ -914,14 +914,24 @@ document.addEventListener('DOMContentLoaded', function () {
                         block.style.borderBottomRightRadius = '';
                     } else {
                         block.style.backgroundColor = color;
-                        block.style.paddingLeft = '6px';
-                        block.style.paddingRight = '6px';
-                        const first = index === 0;
-                        const last = index === elements.length - 1;
-                        block.style.borderTopLeftRadius = first ? '6px' : '0';
-                        block.style.borderTopRightRadius = first ? '6px' : '0';
-                        block.style.borderBottomLeftRadius = last ? '6px' : '0';
-                        block.style.borderBottomRightRadius = last ? '6px' : '0';
+                        if (block.tagName === 'TD' || block.tagName === 'TH') {
+                            // Table cells should keep sharp corners and default padding
+                            block.style.paddingLeft = '';
+                            block.style.paddingRight = '';
+                            block.style.borderTopLeftRadius = '0';
+                            block.style.borderTopRightRadius = '0';
+                            block.style.borderBottomLeftRadius = '0';
+                            block.style.borderBottomRightRadius = '0';
+                        } else {
+                            block.style.paddingLeft = '6px';
+                            block.style.paddingRight = '6px';
+                            const first = index === 0;
+                            const last = index === elements.length - 1;
+                            block.style.borderTopLeftRadius = first ? '6px' : '0';
+                            block.style.borderTopRightRadius = first ? '6px' : '0';
+                            block.style.borderBottomLeftRadius = last ? '6px' : '0';
+                            block.style.borderBottomRightRadius = last ? '6px' : '0';
+                        }
                     }
                 }
             });
@@ -2219,18 +2229,30 @@ document.addEventListener('DOMContentLoaded', function () {
                         block.style.borderBottomRightRadius = '';
                     } else {
                         block.style.backgroundColor = color;
-                        block.style.paddingLeft = '6px';
-                        block.style.paddingRight = '6px';
-                        // Remove default margins to fuse adjacent highlighted lines
-                        block.style.marginTop = '0px';
-                        block.style.marginBottom = '0px';
-                        // Set border radius based on position in selection
-                        const first = index === 0;
-                        const last = index === elements.length - 1;
-                        block.style.borderTopLeftRadius = first ? '6px' : '0';
-                        block.style.borderTopRightRadius = first ? '6px' : '0';
-                        block.style.borderBottomLeftRadius = last ? '6px' : '0';
-                        block.style.borderBottomRightRadius = last ? '6px' : '0';
+                        if (block.tagName === 'TD' || block.tagName === 'TH') {
+                            // Avoid rounding corners or extra padding for table cells
+                            block.style.paddingLeft = '';
+                            block.style.paddingRight = '';
+                            block.style.marginTop = '';
+                            block.style.marginBottom = '';
+                            block.style.borderTopLeftRadius = '0';
+                            block.style.borderTopRightRadius = '0';
+                            block.style.borderBottomLeftRadius = '0';
+                            block.style.borderBottomRightRadius = '0';
+                        } else {
+                            block.style.paddingLeft = '6px';
+                            block.style.paddingRight = '6px';
+                            // Remove default margins to fuse adjacent highlighted lines
+                            block.style.marginTop = '0px';
+                            block.style.marginBottom = '0px';
+                            // Set border radius based on position in selection
+                            const first = index === 0;
+                            const last = index === elements.length - 1;
+                            block.style.borderTopLeftRadius = first ? '6px' : '0';
+                            block.style.borderTopRightRadius = first ? '6px' : '0';
+                            block.style.borderBottomLeftRadius = last ? '6px' : '0';
+                            block.style.borderBottomRightRadius = last ? '6px' : '0';
+                        }
                     }
                 }
             });

--- a/table-resize.js
+++ b/table-resize.js
@@ -110,7 +110,7 @@ export function makeTableResizable(table, { minSize = 30 } = {}) {
     if (!row) return -1;
     for (let i = 0; i < row.cells.length; i++) {
       left += row.cells[i].offsetWidth;
-      if (Math.abs(x - left) <= 4) return i;
+      if (Math.abs(x - left) <= 6) return i;
     }
     return -1;
   }
@@ -119,7 +119,7 @@ export function makeTableResizable(table, { minSize = 30 } = {}) {
     let top = 0;
     for (let i = 0; i < table.rows.length; i++) {
       top += table.rows[i].offsetHeight;
-      if (Math.abs(y - top) <= 4) return i;
+      if (Math.abs(y - top) <= 6) return i;
     }
     return -1;
   }


### PR DESCRIPTION
## Summary
- keep table cell highlights rectangular instead of rounded
- prevent editor toolbar popovers from being clipped
- enlarge table resize handle and detection area for easier table resizing

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afcbcf88a0832ca35836fd576c5f79