### PR TITLE
Add text alignment toolbar buttons

### DIFF
--- a/index.js
+++ b/index.js
@@ -2208,6 +2208,12 @@ document.addEventListener('DOMContentLoaded', function () {
         editorToolbar.appendChild(createButton('Deshacer', '↺', 'undo'));
         editorToolbar.appendChild(createButton('Rehacer', '↻', 'redo'));
 
+        editorToolbar.appendChild(createSeparator());
+        editorToolbar.appendChild(createButton('Alinear izquierda', 'L', 'justifyLeft'));
+        editorToolbar.appendChild(createButton('Centrar', 'C', 'justifyCenter'));
+        editorToolbar.appendChild(createButton('Alinear derecha', 'R', 'justifyRight'));
+        editorToolbar.appendChild(createButton('Justificar', 'J', 'justifyFull'));
+
         const eraserSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-eraser w-5 h-5"><path d="m7 21-4.3-4.3c-1-1-1-2.5 0-3.4l9.6-9.6c1-1 2.5-1 3.4 0l5.6 5.6c1 1 1 2.5 0 3.4L13 21H7Z"/><path d="M22 21H7"/><path d="m5 12 5 5"/></svg>`;
         editorToolbar.appendChild(createButton('Borrar formato', eraserSVG, 'removeFormat'));
 


### PR DESCRIPTION
## Summary
- add toolbar buttons for left, center, right, and full text alignment
- separate alignment controls from formatting group

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afd86bd024832cbc8316f42dae9150