### PR TITLE
Fix callout list splitting

### DIFF
--- a/index.css
+++ b/index.css
@@ -850,6 +850,14 @@ table.resizable-table .table-resize-handle {
     padding: 8px;
     margin: 8px 0;
 }
+.note-callout-content {
+    outline: none;
+}
+.note-callout ul,
+.note-callout ol {
+    margin: 0;
+    padding-left: 1.25rem;
+}
 .note-resizable {
     resize: horizontal;
     overflow: auto;

--- a/index.js
+++ b/index.js
@@ -2619,14 +2619,25 @@ document.addEventListener('DOMContentLoaded', function () {
                     savedEditorSelection.insertNode(callout);
                 }
             } else if (savedEditorSelection) {
-                callout.textContent = 'Escribe una nota...';
                 savedEditorSelection.insertNode(callout);
             } else {
-                callout.textContent = 'Escribe una nota...';
                 notesEditor.appendChild(callout);
             }
             currentCallout = callout;
         }
+        if (!currentCallout.querySelector('.note-callout-content')) {
+            const inner = document.createElement('div');
+            inner.className = 'note-callout-content';
+            inner.contentEditable = 'true';
+            while (currentCallout.firstChild) {
+                inner.appendChild(currentCallout.firstChild);
+            }
+            if (!inner.textContent.trim()) {
+                inner.textContent = 'Escribe una nota...';
+            }
+            currentCallout.appendChild(inner);
+        }
+        currentCallout.contentEditable = 'false';
         currentCallout.classList.remove(...PREDEF_CLASSES);
         if (opts.presetClass) currentCallout.classList.add(opts.presetClass);
         currentCallout.style.backgroundColor = opts.backgroundColor;
@@ -2640,12 +2651,14 @@ document.addEventListener('DOMContentLoaded', function () {
         } else {
             currentCallout.classList.remove('note-shadow');
         }
+        const inner = currentCallout.querySelector('.note-callout-content');
         const range = document.createRange();
-        range.selectNodeContents(currentCallout);
+        range.selectNodeContents(inner);
         range.collapse(false);
         const selection = window.getSelection();
         selection.removeAllRanges();
         selection.addRange(range);
+        inner.focus();
         notesEditor.focus();
         closeNoteStyleModal();
     }


### PR DESCRIPTION
## Summary
- Preserve callout container and add inner editable element to avoid splitting when creating lists
- Adjust callout styles to support nested lists

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0bd63b644832ca6272eab49131742