### PR TITLE
Add column selection, local indent, and format painter

### DIFF
--- a/index.css
+++ b/index.css
@@ -865,6 +865,11 @@ table.resizable-table .table-resize-handle {
 .indent-3 { margin-left: 3rem; }
 .indent-4 { margin-left: 4rem; }
 .indent-5 { margin-left: 5rem; }
+.inline-indent-1 { display: inline-block; margin-left: 1rem; }
+.inline-indent-2 { display: inline-block; margin-left: 2rem; }
+.inline-indent-3 { display: inline-block; margin-left: 3rem; }
+.inline-indent-4 { display: inline-block; margin-left: 4rem; }
+.inline-indent-5 { display: inline-block; margin-left: 5rem; }
 .note-resizable {
     resize: horizontal;
     overflow: auto;


### PR DESCRIPTION
## Summary
- Allow selecting an entire table column for formatting
- Provide local indent controls that only affect the selected line
- Add format painter buttons to copy and apply styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b34aad9374832c8101fa95d89e273d