### PR TITLE
feat: add pastel theme option

### DIFF
--- a/index.css
+++ b/index.css
@@ -62,6 +62,19 @@
             --section-header-text: #f3f4f6;
         }
 
+        html[data-theme="pastel"] {
+            --header-bg: #fbcfe8;
+            --section-header-bg: linear-gradient(to right, #fce7f3, #fbcfe8);
+            --section-header-text: #831843;
+            --btn-primary-bg: #f472b6;
+        }
+        html[data-theme="pastel"].dark {
+            --header-bg: #9d174d;
+            --section-header-bg: linear-gradient(to right, #831843, #9d174d);
+            --section-header-text: #fce7f3;
+            --btn-primary-bg: #be185d;
+        }
+
 
         body { font-family: 'Inter', sans-serif; background-color: var(--bg-primary); color: var(--text-primary); }
 

--- a/index.html
+++ b/index.html
@@ -83,6 +83,7 @@
                                 <a href="#" class="theme-option block px-3 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700" data-theme="ocean">Océano</a>
                                 <a href="#" class="theme-option block px-3 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700" data-theme="forest">Bosque</a>
                                 <a href="#" class="theme-option block px-3 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700" data-theme="minimalist">Minimalista</a>
+                                <a href="#" class="theme-option block px-3 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700" data-theme="pastel">Pastel</a>
                                 <div class="border-t border-gray-200 dark:border-gray-700 my-1"></div>
                                 <div class="px-3 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">Estilo de Iconos</div>
                                 <a href="#" class="icon-style-option block px-3 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700" data-style="solid">Sólido</a>


### PR DESCRIPTION
## Summary
- add pastel color theme for a softer look
- expose Pastel option in theme selector

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b39b2509f4832c8567a408b32da996