### PR TITLE
feat: improve editor with advanced selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ This contains everything you need to run your app locally.
 ### Features
 
 - Nueva herramienta en el editor para redimensionar lateralmente notas o bloques HTML insertados mediante el botón ↔️ de la barra de herramientas.
+- Experiencia de edición mejorada: multicursor, selección en bloques y reorganización de líneas con arrastrar y soltar.

--- a/editor-enhancements.js
+++ b/editor-enhancements.js
@@ -1,0 +1,112 @@
+export function setupAdvancedEditing(editor) {
+  const extraCursors = [];
+  function clearExtraCursors() {
+    extraCursors.forEach(c => c.marker.remove());
+    extraCursors.length = 0;
+  }
+
+  editor.addEventListener('click', e => {
+    if (e.altKey) {
+      const sel = window.getSelection();
+      if (!sel || !sel.rangeCount) return;
+      const range = sel.getRangeAt(0).cloneRange();
+      const marker = document.createElement('span');
+      marker.className = 'extra-cursor';
+      marker.innerHTML = '\u200b';
+      range.insertNode(marker);
+      range.setStartAfter(marker);
+      range.collapse(true);
+      extraCursors.push({ range, marker });
+    } else {
+      clearExtraCursors();
+    }
+  });
+
+  editor.addEventListener('keydown', e => {
+    if (!extraCursors.length) return;
+    if (e.key.length === 1 && !e.metaKey && !e.ctrlKey) {
+      const char = e.key;
+      extraCursors.forEach(cur => {
+        const text = document.createTextNode(char);
+        cur.range.insertNode(text);
+        cur.range.setStartAfter(text);
+        cur.range.collapse(true);
+      });
+    } else if (e.key === 'Backspace') {
+      extraCursors.forEach(cur => {
+        const r = cur.range;
+        r.setStart(r.startContainer, Math.max(r.startOffset - 1, 0));
+        r.deleteContents();
+      });
+    }
+  });
+
+  let blockStart = null;
+  editor.addEventListener('mousedown', e => {
+    if (e.altKey) {
+      e.preventDefault();
+      blockStart = { x: e.clientX, y: e.clientY };
+      const sel = window.getSelection();
+      sel.removeAllRanges();
+      editor.addEventListener('mousemove', onBlockMove);
+      document.addEventListener('mouseup', onBlockEnd);
+    }
+  });
+  function onBlockMove(e) {
+    if (!blockStart) return;
+    const sel = window.getSelection();
+    const start = caretFromPoint(blockStart.x, blockStart.y);
+    const end = caretFromPoint(e.clientX, e.clientY);
+    if (start && end) {
+      const range = document.createRange();
+      range.setStart(start.node, start.offset);
+      range.setEnd(end.node, end.offset);
+      sel.removeAllRanges();
+      sel.addRange(range);
+    }
+  }
+  function onBlockEnd() {
+    editor.removeEventListener('mousemove', onBlockMove);
+    document.removeEventListener('mouseup', onBlockEnd);
+    blockStart = null;
+  }
+  function caretFromPoint(x, y) {
+    if (document.caretPositionFromPoint) {
+      const pos = document.caretPositionFromPoint(x, y);
+      return { node: pos.offsetNode, offset: pos.offset };
+    }
+    if (document.caretRangeFromPoint) {
+      const range = document.caretRangeFromPoint(x, y);
+      return { node: range.startContainer, offset: range.startOffset };
+    }
+    return null;
+  }
+
+  let dragLine = null;
+  editor.addEventListener('dragstart', e => {
+    const line = e.target.closest('p');
+    if (!line) return;
+    dragLine = line;
+    e.dataTransfer.setData('text/plain', '');
+  });
+  editor.addEventListener('dragover', e => {
+    const line = e.target.closest('p');
+    if (!line || !dragLine || line === dragLine) return;
+    e.preventDefault();
+  });
+  editor.addEventListener('drop', e => {
+    const line = e.target.closest('p');
+    if (!line || !dragLine || line === dragLine) return;
+    e.preventDefault();
+    editor.insertBefore(dragLine, line);
+    dragLine = null;
+  });
+
+  editor.querySelectorAll('p').forEach(p => p.setAttribute('draggable', 'true'));
+  const observer = new MutationObserver(() => {
+    editor.querySelectorAll('p').forEach(p => {
+      if (!p.getAttribute('draggable')) p.setAttribute('draggable', 'true');
+    });
+  });
+  observer.observe(editor, { childList: true, subtree: true });
+}

--- a/index.css
+++ b/index.css
@@ -1025,3 +1025,14 @@ table.resizable-table .table-resize-handle {
   body {
     padding-top: 32px;
   }
+
+.extra-cursor {
+  border-left: 1px solid var(--text-primary);
+  margin-left: -1px;
+  pointer-events: none;
+  animation: blink 1s steps(1) infinite;
+}
+
+@keyframes blink {
+  50% { border-color: transparent; }
+}

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ import { makeTableResizable } from './table-resize.js';
 import { setupAdvancedSearchReplace } from './search-replace.js';
 import { setupKeyboardShortcuts } from './shortcuts.js';
 import { setupCloudIntegration } from './cloud-sync.js';
+import { setupAdvancedEditing } from './editor-enhancements.js';
 
 const pdfjsLib = typeof window !== 'undefined' ? window['pdfjsLib'] : null;
 if (pdfjsLib) {
@@ -5630,6 +5631,7 @@ document.addEventListener('DOMContentLoaded', function () {
         applyTheme(document.documentElement.dataset.theme || 'default');
         setupAdvancedSearchReplace();
         setupKeyboardShortcuts();
+        setupAdvancedEditing(notesEditor);
         setupCloudIntegration();
     }
 


### PR DESCRIPTION
## Summary
- add advanced editing utilities enabling multi-cursor typing, block selection and line drag-and-drop
- style for extra carets and hook advanced editing into main editor
- document improved editing features in README

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3b1275f80832cb4a6e58ce3d42d0b