### PR TITLE
feat: select table column with hover button

### DIFF
--- a/index.css
+++ b/index.css
@@ -397,6 +397,18 @@ table.resizable-table .table-resize-handle {
     box-sizing: border-box;
 }
 
+table.resizable-table .table-col-select-btn {
+    display: none;
+    padding: 2px 4px;
+    font-size: 0.75rem;
+    line-height: 1;
+    border: 1px solid var(--border-color);
+    background-color: var(--bg-tertiary);
+    color: var(--text-secondary);
+    border-radius: 3px;
+    cursor: pointer;
+}
+
 /* Floating image styles */
 .float-image {
     display: block;

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@
 // inline IndexedDB implementation and keeps the rest of the code unchanged.
 import db from './db.js';
 import { makeTableResizable } from './table-resize.js';
+import { enableTableColumnSelection } from './table-column-select.js';
 import { setupAdvancedSearchReplace } from './search-replace.js';
 import { setupKeyboardShortcuts } from './shortcuts.js';
 import { setupCloudIntegration } from './cloud-sync.js';
@@ -3670,6 +3671,7 @@ document.addEventListener('DOMContentLoaded', function () {
         if (table.dataset.resizableInitialized === 'true') return;
         table.classList.add('resizable-table');
         makeTableResizable(table);
+        enableTableColumnSelection(table);
         table.dataset.resizableInitialized = 'true';
     }
 

--- a/table-column-select.js
+++ b/table-column-select.js
@@ -1,0 +1,76 @@
+export function enableTableColumnSelection(table) {
+  let hoverCol = -1;
+  const btn = document.createElement('button');
+  btn.className = 'table-col-select-btn';
+  btn.textContent = '\u25BC';
+  btn.style.position = 'absolute';
+  btn.style.top = '-14px';
+  btn.style.left = '50%';
+  btn.style.transform = 'translateX(-50%)';
+  btn.style.display = 'none';
+  btn.type = 'button';
+
+  table.addEventListener('mousemove', onMove);
+  table.addEventListener('mouseleave', hideButton);
+  btn.addEventListener('mousedown', e => e.stopPropagation());
+  btn.addEventListener('click', onClick);
+
+  function onMove(e) {
+    const rect = table.getBoundingClientRect();
+    const y = e.clientY - rect.top;
+    if (y > 5) {
+      hideButton();
+      return;
+    }
+    const x = e.clientX - rect.left;
+    const col = findCol(x);
+    if (col === -1) {
+      hideButton();
+      return;
+    }
+    if (hoverCol !== col) {
+      hoverCol = col;
+      const cell = table.rows[0].cells[col];
+      cell.appendChild(btn);
+    }
+    btn.style.display = 'block';
+  }
+
+  function hideButton() {
+    hoverCol = -1;
+    btn.style.display = 'none';
+  }
+
+  function onClick(e) {
+    e.preventDefault();
+    const col = hoverCol;
+    if (col === -1) return;
+    selectColumn(col);
+  }
+
+  function findCol(x) {
+    let left = 0;
+    const row = table.rows[0];
+    if (!row) return -1;
+    for (let i = 0; i < row.cells.length; i++) {
+      const width = row.cells[i].offsetWidth;
+      if (x >= left && x <= left + width) return i;
+      left += width;
+    }
+    return -1;
+  }
+
+  function selectColumn(index) {
+    const sel = window.getSelection();
+    if (!sel) return;
+    sel.removeAllRanges();
+    for (const row of table.rows) {
+      const cell = row.cells[index];
+      if (cell) {
+        const range = document.createRange();
+        range.selectNodeContents(cell);
+        sel.addRange(range);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add button that appears when hovering over top edge of a table column
- allow selecting entire column to apply editor formatting
- style column select button and integrate into table initialization

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3d2502ac0832c8d4e0ba7c479779d