### PR TITLE
Ensure OpenAI API key is loaded from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This contains everything you need to run your app locally.
 
 1. Install dependencies:
    `npm install`
-2. Set the `OPENAI_API_KEY` in your Netlify environment settings (or in [.env.local](.env.local) for local testing)
+2. Set the `OPENAI_API_KEY` in your Netlify environment settings (or in [.env.local](.env.local) for local testing). The key is exposed to the client at build time, so remember to rebuild the site after changing it.
 3. Run the app:
    `npm run dev`
 

--- a/ai-tools.js
+++ b/ai-tools.js
@@ -1,5 +1,6 @@
 export async function callOpenAI(messages) {
-  const apiKey = process.env.OPENAI_API_KEY;
+  // The key can come from Vite's exposed env or from a Node environment
+  const apiKey = import.meta.env?.VITE_OPENAI_API_KEY || process.env.OPENAI_API_KEY;
   if (!apiKey) throw new Error('Falta la clave API');
   const res = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,12 +2,16 @@ import path from 'path';
 import { defineConfig, loadEnv } from 'vite';
 
 export default defineConfig(({ mode }) => {
-    const env = loadEnv(mode, '.', '');
+    // Merge actual environment variables with those from .env files
+    const env = { ...process.env, ...loadEnv(mode, '.', '') };
+    const openaiKey = env.OPENAI_API_KEY || '';
     return {
       define: {
-        'process.env.API_KEY': JSON.stringify(env.OPENAI_API_KEY),
-        'process.env.OPENAI_API_KEY': JSON.stringify(env.OPENAI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        // Expose the OpenAI key to the client bundle when building
+        'process.env.API_KEY': JSON.stringify(openaiKey),
+        'process.env.OPENAI_API_KEY': JSON.stringify(openaiKey),
+        'import.meta.env.VITE_OPENAI_API_KEY': JSON.stringify(openaiKey),
+        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY || '')
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- merge process.env with Vite env loading so Netlify variables are available
- allow OpenAI tools to read the key from exposed env variables
- document the need to rebuild after setting OPENAI_API_KEY

## Testing
- `npm test` *(fails: Missing script: "test")*
- `OPENAI_API_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b471a998ec832ca6ff30ef959a45d5