### PR TITLE
Improve OpenAI key handling for Netlify deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables
+# Rename this file to .env or set these variables in your hosting service.
+OPENAI_API_KEY=
+VITE_OPENAI_API_KEY=
+GEMINI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This contains everything you need to run your app locally.
 
 1. Install dependencies:
    `npm install`
-2. Set the `OPENAI_API_KEY` in your Netlify environment settings (or in [.env.local](.env.local) for local testing)
+2. Set the `OPENAI_API_KEY` (or `VITE_OPENAI_API_KEY`) in your Netlify environment settings or in a `.env` file for local testing.
 3. Run the app:
    `npm run dev`
 

--- a/ai-tools.js
+++ b/ai-tools.js
@@ -1,5 +1,8 @@
 export async function callOpenAI(messages) {
-  const apiKey = process.env.OPENAI_API_KEY;
+  const apiKey =
+    import.meta.env.VITE_OPENAI_API_KEY ||
+    import.meta.env.OPENAI_API_KEY ||
+    process.env.OPENAI_API_KEY;
   if (!apiKey) throw new Error('Falta la clave API');
   const res = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,9 +5,11 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
       define: {
-        'process.env.API_KEY': JSON.stringify(env.OPENAI_API_KEY),
         'process.env.OPENAI_API_KEY': JSON.stringify(env.OPENAI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        'import.meta.env.OPENAI_API_KEY': JSON.stringify(env.OPENAI_API_KEY),
+        'import.meta.env.VITE_OPENAI_API_KEY': JSON.stringify(env.VITE_OPENAI_API_KEY),
+        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
+        'import.meta.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- read OpenAI key from `import.meta.env` with fallbacks and add env example file
- expose environment variables in Vite config for browser access
- clarify README instructions for setting API keys

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b471a998ec832ca6ff30ef959a45d5