### PR TITLE
Fix indent logic to avoid wrapping unintended blocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -2033,7 +2033,21 @@ document.addEventListener('DOMContentLoaded', function () {
             });
             let current;
             while ((current = walker.nextNode())) {
-                if (!blocks.some(b => b.contains(current))) blocks.push(current);
+                let replaced = false;
+                for (let i = 0; i < blocks.length; i++) {
+                    const b = blocks[i];
+                    if (b.contains(current)) {
+                        // Replace ancestor block with more specific descendant
+                        blocks[i] = current;
+                        replaced = true;
+                        break;
+                    } else if (current.contains(b)) {
+                        // Current node is an ancestor of an existing block; ignore it
+                        replaced = true;
+                        break;
+                    }
+                }
+                if (!replaced) blocks.push(current);
             }
             if (!blocks.length) {
                 const newBlock = document.createElement('p');


### PR DESCRIPTION
## Summary
- ensure indent command targets deepest blocks instead of broad ancestors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4f2911bbc832c93446a452ff59f70