### PR TITLE
Fix indentation wrapping

### DIFF
--- a/index.js
+++ b/index.js
@@ -2036,9 +2036,16 @@ document.addEventListener('DOMContentLoaded', function () {
                 if (!blocks.some(b => b.contains(current))) blocks.push(current);
             }
             if (!blocks.length) {
-                const newBlock = document.createElement('p');
-                range.surroundContents(newBlock);
-                blocks.push(newBlock);
+                let block = node.closest('p, li, div, table');
+                if (block && root.contains(block)) {
+                    blocks.push(block);
+                } else {
+                    const newBlock = document.createElement('p');
+                    const frag = range.extractContents();
+                    newBlock.appendChild(frag);
+                    range.insertNode(newBlock);
+                    blocks.push(newBlock);
+                }
             }
 
             blocks.forEach(block => {


### PR DESCRIPTION
## Summary
- prevent indentation helper from wrapping more content than selected
- ensure indent applies only to existing block or newly inserted one

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4f2911bbc832c93446a452ff59f70