### PR TITLE
feat: add manual block outdent button

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ This contains everything you need to run your app locally.
 
 - Nueva herramienta en el editor para redimensionar lateralmente notas o bloques HTML insertados mediante el botón ↔️ de la barra de herramientas.
 - Experiencia de edición mejorada: multicursor, selección en bloques y reorganización de líneas con arrastrar y soltar.
+- Botones para corregir la sangría de un bloque seleccionado.  Usa ↦ para aumentar un nivel de `indent-n` o ↤ para reducirlo.


### PR DESCRIPTION
## Summary
- implement `manualOutdentBlock` to remove an `indent-n` class from the current block
- add "Corregir sangría inversa" toolbar button invoking the new helper
- document manual indent/outdent usage in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b528cec7c0832c979f06d70be33439