### PR TITLE
fix: remove blank page before first topic

### DIFF
--- a/index.css
+++ b/index.css
@@ -821,6 +821,10 @@ table.resizable-table .table-resize-handle {
             .section-cover-page + .topic-print-wrapper {
                 page-break-before: auto;
             }
+            #print-index + .section-cover-page,
+            #print-index + .topic-print-wrapper {
+                page-break-before: auto;
+            }
             /* Ensure side-by-side images print in the same row */
             #notes-editor .image-row,
             #print-area .image-row {

--- a/index.js
+++ b/index.js
@@ -4276,7 +4276,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 const cover = document.createElement('div');
                 cover.className = 'section-cover-page';
                 cover.id = `print-section-${sectionId}`;
-                if (printArea.children.length > 0) {
+                if (printArea.children.length > 0 && printArea.lastElementChild.id !== 'print-index') {
                     cover.style.pageBreakBefore = 'always';
                 }
                 const titleEl = document.createElement('h1');


### PR DESCRIPTION
## Summary
- Prevent double page breaks after the index so content prints continuously
- Skip forcing page break before section covers when index is the previous element

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b77174c61c832cb1ac5fe55b35f886