### PR TITLE
Add resizable table demo and utilities

### DIFF
--- a/resizable-table-demo.html
+++ b/resizable-table-demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Demo Tablas Redimensionables</title>
+<link rel="stylesheet" href="resizable-table.css" />
+</head>
+<body>
+<h1>Ejemplos de tablas redimensionables</h1>
+
+<div class="indent-1">
+  <table class="resizable-table tabla-estandar" data-example="a">
+    <tr class="header"><td>Enfrentamiento de HTA Resistente (ESC 2024)</td></tr>
+    <tr>
+      <td>
+        <ul>
+          <li>Confirmar adherencia y técnica correcta</li>
+          <li>Añadir diurético tiazídico potente</li>
+          <li>Evaluar causas secundarias</li>
+        </ul>
+      </td>
+    </tr>
+  </table>
+</div>
+
+<div class="indent-1">
+  <table class="resizable-table tabla-estandar" data-example="b">
+    <tr class="header"><td>Término</td><td>Definición</td></tr>
+    <tr><td>HTA resistente</td><td>PA no controlada pese a 3 fármacos</td></tr>
+    <tr><td>HTA refractaria</td><td>PA no controlada pese a ≥5 fármacos</td></tr>
+  </table>
+</div>
+
+<div class="indent-2">
+  <table class="resizable-table tabla-estandar" data-example="c">
+    <tr class="header"><td>Grupo</td><td>Causa</td><td>Frecuencia</td></tr>
+    <tr><td rowspan="2">Cardíacas</td><td>Insuficiencia cardiaca</td><td>Alta</td></tr>
+    <tr style="background:#fff9c4"><td>Valvulopatías</td><td>Media</td></tr>
+    <tr><td>Renales</td><td style="background:#fff9c4">Estenosis de arteria renal</td><td>Baja</td></tr>
+  </table>
+</div>
+
+<script src="resizable-table.js"></script>
+<script>
+  initResizableTables();
+</script>
+</body>
+</html>

--- a/resizable-table.css
+++ b/resizable-table.css
@@ -1,0 +1,66 @@
+/* Base typography and table look */
+body {
+  font-family: sans-serif;
+  font-size: 13px;
+  line-height: 1.1;
+}
+
+.indent-1 { margin-left: 20px; }
+.indent-2 { margin-left: 40px; }
+
+/* Table visuals */
+table.resizable-table {
+  border-collapse: collapse;
+  border: 1px solid #999;
+  position: relative;
+  width: auto;
+}
+
+table.resizable-table td {
+  border: 1px solid #999;
+  padding: 2px 4px;
+  position: relative;
+}
+
+/* Header row styling (no sticky) */
+table.resizable-table tr.header {
+  background: #e6f0fa !important;
+  position: static !important;
+  z-index: auto !important;
+}
+
+/* Corner handle */
+table.resizable-table .resize-handle {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  right: 0;
+  bottom: 0;
+  cursor: se-resize;
+  background: rgba(0,0,0,0.2);
+  border-radius: 2px;
+  display: none;
+}
+
+table.resizable-table:hover .resize-handle,
+table.resizable-table:focus-within .resize-handle {
+  display: block;
+}
+
+/* Guide line while resizing */
+.resize-guide {
+  position: absolute;
+  background: #0d6efd;
+  pointer-events: none;
+  z-index: 1000;
+}
+
+@media print {
+  table.resizable-table {
+    page-break-inside: auto;
+  }
+  table.resizable-table tr {
+    page-break-inside: avoid;
+    page-break-after: auto;
+  }
+}

--- a/resizable-table.js
+++ b/resizable-table.js
@@ -1,0 +1,233 @@
+/* Resizable table component
+   initResizableTables(root) -> scan DOM and set up tables.
+   destroyResizableTable(table) -> remove listeners if table removed.
+*/
+// Minimal vanilla JS table resizer
+// Call initResizableTables() after inserting tables into the DOM.
+(function(){
+  function initResizableTable(table){
+    if (table.dataset.resizableInitialized === 'true') return;
+    table.dataset.resizableInitialized = 'true';
+
+    const handle = document.createElement('div');
+    handle.className = 'resize-handle';
+    table.appendChild(handle);
+
+    handle.addEventListener('mousedown', startTableResize);
+    table.addEventListener('mousemove', detectEdge);
+    table.addEventListener('mousedown', startCellResize);
+    table.addEventListener('dblclick', autoFit);
+  }
+
+  function initResizableTables(root=document){
+    root.querySelectorAll('table.resizable-table').forEach(initResizableTable);
+  }
+
+  // --- Table corner resize ---
+  function startTableResize(e){
+    e.preventDefault();
+    const table = e.target.parentElement;
+    const startX = e.clientX;
+    const startY = e.clientY;
+    const startW = table.offsetWidth;
+    const startH = table.offsetHeight;
+    document.documentElement.style.userSelect = 'none';
+    function onMove(ev){
+      const dx = ev.clientX - startX;
+      const dy = ev.clientY - startY;
+      table.style.width = startW + dx + 'px';
+      table.style.height = startH + dy + 'px';
+    }
+    function onUp(){
+      document.documentElement.style.userSelect = '';
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+    }
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  }
+
+  // --- Column/row resize ---
+  let mode = null; // 'col' or 'row'
+  let index = null;
+  let startPos = 0;
+  let startSize = 0;
+  let guide = null;
+  function detectEdge(e){
+    const cell = e.target.closest('td,th');
+    if(!cell || !e.currentTarget.contains(cell)) return;
+    const rect = cell.getBoundingClientRect();
+    const offsetX = e.clientX - rect.left;
+    const offsetY = e.clientY - rect.top;
+    const right = rect.width - offsetX;
+    const bottom = rect.height - offsetY;
+    const table = e.currentTarget;
+    table.style.cursor = '';
+    if(right < 4){ table.style.cursor = 'col-resize'; }
+    else if(bottom < 4){ table.style.cursor = 'row-resize'; }
+  }
+
+  function startCellResize(e){
+    const table = e.currentTarget;
+    const cell = e.target.closest('td,th');
+    if(!cell) return;
+    const rect = cell.getBoundingClientRect();
+    const offsetX = e.clientX - rect.left;
+    const offsetY = e.clientY - rect.top;
+    const right = rect.width - offsetX;
+    const bottom = rect.height - offsetY;
+    if(right >=4 && bottom >=4) return; // not on edge
+    e.preventDefault();
+    document.documentElement.style.userSelect = 'none';
+    if(right < bottom){
+      mode = 'col';
+      index = cell.cellIndex;
+      startPos = e.clientX;
+      startSize = getColumnWidth(table, index);
+      guide = makeGuide('col', e.clientX, table);
+    }else{
+      mode = 'row';
+      index = cell.parentElement.rowIndex;
+      startPos = e.clientY;
+      startSize = getRowHeight(table, index);
+      guide = makeGuide('row', e.clientY, table);
+    }
+    document.addEventListener('mousemove', doCellResize);
+    document.addEventListener('mouseup', finishCellResize);
+  }
+
+  function doCellResize(ev){
+    if(!mode) return;
+    const delta = (mode==='col'? ev.clientX - startPos : ev.clientY - startPos);
+    if(mode==='col'){
+      guide.style.left = startPos + delta + 'px';
+    }else{
+      guide.style.top = startPos + delta + 'px';
+    }
+  }
+
+  function finishCellResize(ev){
+    const table = eTable(guide);
+    document.documentElement.style.userSelect = '';
+    document.removeEventListener('mousemove', doCellResize);
+    document.removeEventListener('mouseup', finishCellResize);
+    if(!mode) return;
+    const delta = (mode==='col'? ev.clientX - startPos : ev.clientY - startPos);
+    const newSize = startSize + delta;
+    if(mode==='col'){
+      if(ev.altKey && index>0){
+         const prevW = getColumnWidth(table,index-1);
+         setColumnWidth(table,index-1, prevW - delta, ev);
+      }
+      if(ev.shiftKey){
+         const cells = Array.from(table.rows[0].cells).filter((c,i)=>i!==index && (!ev.altKey || i!==index-1));
+         const share = delta / cells.length;
+         cells.forEach(c=>{
+             const w = getColumnWidth(table,c.cellIndex);
+             setColumnWidth(table,c.cellIndex, w - share, ev);
+         });
+      }
+      setColumnWidth(table, index, newSize, ev);
+    }else{
+      if(ev.altKey && index>0){
+         const prevH = getRowHeight(table,index-1);
+         setRowHeight(table,index-1, prevH - delta, ev);
+      }
+      if(ev.shiftKey){
+         const rows = Array.from(table.rows).filter((r,i)=>i!==index && (!ev.altKey || i!==index-1));
+         const share = delta / rows.length;
+         rows.forEach(r=>{
+             const h = getRowHeight(table,r.rowIndex);
+             setRowHeight(table,r.rowIndex, h - share, ev);
+         });
+      }
+      setRowHeight(table, index, newSize, ev);
+    }
+    guide.remove();
+    mode = null;
+  }
+
+  function autoFit(e){
+    const table = e.currentTarget;
+    const cell = e.target.closest('td,th');
+    if(!cell) return;
+    const rect = cell.getBoundingClientRect();
+    const offsetX = e.clientX - rect.left;
+    const offsetY = e.clientY - rect.top;
+    const right = rect.width - offsetX;
+    const bottom = rect.height - offsetY;
+    if(right < 4){
+      const idx = cell.cellIndex;
+      let max = 0;
+      Array.from(table.rows).forEach(r=>{
+        const c = r.cells[idx];
+        if(!c) return;
+        c.style.width = 'auto';
+        const w = c.scrollWidth + 4;
+        if(w>max) max = w;
+      });
+      setColumnWidth(table, idx, max, e);
+    }else if(bottom < 4){
+      const idx = cell.parentElement.rowIndex;
+      const r = table.rows[idx];
+      r.style.height = 'auto';
+      const h = r.scrollHeight + 4;
+      setRowHeight(table, idx, h, e);
+    }
+  }
+
+  function makeGuide(type, pos, table){
+    const g = document.createElement('div');
+    g.className = 'resize-guide';
+    const rect = table.getBoundingClientRect();
+    if(type==='col'){
+      g.style.top = rect.top + 'px';
+      g.style.bottom = (window.innerHeight - rect.bottom) + 'px';
+      g.style.width = '1px';
+      g.style.left = pos + 'px';
+    }else{
+      g.style.left = rect.left + 'px';
+      g.style.right = (window.innerWidth - rect.right) + 'px';
+      g.style.height = '1px';
+      g.style.top = pos + 'px';
+    }
+    document.body.appendChild(g);
+    return g;
+  }
+
+  function getColumnWidth(table, idx){
+    const cell = table.rows[0].cells[idx];
+    return parseInt(getComputedStyle(cell).width,10);
+  }
+  function setColumnWidth(table, idx, width, ev){
+    Array.from(table.rows).forEach(r=>{
+      const c = r.cells[idx];
+      if(c) c.style.width = width + 'px';
+    });
+  }
+  function getRowHeight(table, idx){
+    const row = table.rows[idx];
+    return parseInt(getComputedStyle(row).height,10);
+  }
+  function setRowHeight(table, idx, h, ev){
+    const row = table.rows[idx];
+    row.style.height = h + 'px';
+  }
+  function eTable(el){
+    return el.closest('table');
+  }
+
+  // expose
+  function destroyResizableTable(table){
+    if(!table) return;
+    const handle = table.querySelector('.resize-handle');
+    if(handle) handle.remove();
+    table.removeEventListener('mousemove', detectEdge);
+    table.removeEventListener('mousedown', startCellResize);
+    table.removeEventListener('dblclick', autoFit);
+    table.dataset.resizableInitialized = 'false';
+  }
+
+  window.initResizableTables = initResizableTables;
+  window.destroyResizableTable = destroyResizableTable;
+})();


### PR DESCRIPTION
## Summary
- add standalone demo for resizable tables with standard styling
- implement vanilla JS resizable table component with corner, column and row handles
- provide print-safe CSS and initialization/cleanup helpers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b785132bd8832c9d79782d79e18c2d