### PR TITLE
Add resizable table component and demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,13 @@ This contains everything you need to run your app locally.
 - Nueva herramienta en el editor para redimensionar lateralmente notas o bloques HTML insertados mediante el botón ↔️ de la barra de herramientas.
 - Experiencia de edición mejorada: multicursor, selección en bloques y reorganización de líneas con arrastrar y soltar.
 - Botones para corregir la sangría de un bloque seleccionado.  Usa ↦ para aumentar un nivel de `indent-n` o ↤ para reducirlo.
+
+## Resizable tables
+
+Files `resizable-table.css` and `resizable-table.js` provide a vanilla component to resize tables.
+Use the class `resizable-table` on `<table>` elements and call `initResizableTables()` after inserting
+or pasting new tables. The function marks each table with `data-resizable-initialized="true"` so
+repeated calls are safe. To remove listeners simply remove the table element; global listeners stop
+acting when the table disappears.
+
+`resizable-table-demo.html` shows three example tables and how to initialise the component.

--- a/resizable-table-demo.html
+++ b/resizable-table-demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Demo Tablas Redimensionables</title>
+<link rel="stylesheet" href="resizable-table.css">
+</head>
+<body>
+<h2>Enfrentamiento de HTA Resistente (ESC 2024)</h2>
+<table class="resizable-table tabla-estandar indent-1">
+  <tr>
+    <td>Medidas</td>
+    <td>Detalles</td>
+  </tr>
+  <tr>
+    <td>
+      <ul>
+        <li>Confirmar adherencia</li>
+        <li>Ajustar terapia</li>
+        <li>Evaluar causas secundarias</li>
+      </ul>
+    </td>
+    <td>Recordar seguimiento cercano.</td>
+  </tr>
+</table>
+
+<h2>Otras definiciones (ESC 2024)</h2>
+<table class="resizable-table tabla-estandar indent-2">
+  <tr>
+    <td>Término</td>
+    <td>Definición</td>
+  </tr>
+  <tr>
+    <td>HTA resistente</td>
+    <td>PA persistente &gt; 140/90 con &ge;3 fármacos.</td>
+  </tr>
+  <tr>
+    <td>HTA refractaria</td>
+    <td>PA no controlada con &ge;5 fármacos.</td>
+  </tr>
+</table>
+
+<h2>Grupos / Causas / Frecuencia</h2>
+<table class="resizable-table tabla-estandar">
+  <tr>
+    <td>Grupo</td>
+    <td>Causa</td>
+    <td>Frecuencia</td>
+  </tr>
+  <tr>
+    <td rowspan="2">Primario</td>
+    <td class="highlight">Hiperaldosteronismo</td>
+    <td>10%</td>
+  </tr>
+  <tr>
+    <td>Falla renal crónica</td>
+    <td>5%</td>
+  </tr>
+  <tr>
+    <td>Secundario</td>
+    <td class="highlight">Estenosis de arteria renal</td>
+    <td>2%</td>
+  </tr>
+</table>
+
+<script src="resizable-table.js"></script>
+<script>
+initResizableTables();
+</script>
+</body>
+</html>

--- a/resizable-table.css
+++ b/resizable-table.css
@@ -1,0 +1,63 @@
+/* CSS for resizable tables */
+.resizable-table {
+  font-family: sans-serif;
+  font-size: 13px;
+  line-height: 1.1;
+  border-collapse: collapse;
+  border: 1px solid #999;
+}
+.resizable-table td {
+  border: 1px solid #999;
+  padding: 4px;
+  position: relative;
+  min-width: 30px;
+  min-height: 24px;
+  vertical-align: top;
+}
+.resizable-table tr:first-child td {
+  background: #e6f0fa !important;
+  position: static !important;
+  z-index: auto !important;
+  font-weight: bold;
+}
+.table-handle {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  bottom: 0;
+  right: 0;
+  background: #666;
+  cursor: se-resize;
+  opacity: 0;
+}
+.resizable-table:hover .table-handle,
+.resizable-table:focus-within .table-handle {
+  opacity: 1;
+}
+.resize-guide {
+  position: absolute;
+  background: #2196f3;
+  pointer-events: none;
+  z-index: 10;
+}
+.resize-guide.vertical {
+  width: 1px;
+  top: 0;
+  bottom: 0;
+}
+.resize-guide.horizontal {
+  height: 1px;
+  left: 0;
+  right: 0;
+}
+.highlight {
+  background: #fff9c4;
+}
+.indent-1 { margin-left: 1rem; }
+.indent-2 { margin-left: 2rem; }
+@media print {
+  .table-handle,
+  .resize-guide {
+    display: none !important;
+  }
+}

--- a/resizable-table.js
+++ b/resizable-table.js
@@ -1,0 +1,216 @@
+// Vanilla JS resizable table component
+(function(){
+  const STEP = 4; // snap step
+  function snap(v){ return Math.round(v/STEP)*STEP; }
+
+  function initResizableTables(root=document){
+    const tables = root.querySelectorAll('table.resizable-table:not([data-resizable-initialized])');
+    tables.forEach(setupTable);
+  }
+
+  function setupTable(table){
+    table.dataset.resizableInitialized = 'true';
+    table.style.position = 'relative';
+    const handle = document.createElement('div');
+    handle.className = 'table-handle';
+    table.appendChild(handle);
+
+    let drag = null;
+    let guide = null;
+
+    table.addEventListener('mousemove', e => {
+      if(drag) return;
+      const rect = table.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const col = getColEdge(table, x);
+      const row = getRowEdge(table, y);
+      if(col > -1) table.style.cursor = 'col-resize';
+      else if(row > -1) table.style.cursor = 'row-resize';
+      else table.style.cursor = '';
+    });
+
+    table.addEventListener('mousedown', e => {
+      if(e.target === handle) return;
+      const rect = table.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const col = getColEdge(table, x);
+      const row = getRowEdge(table, y);
+      if(col > -1){
+        e.preventDefault();
+        startDrag('col', col, e);
+      } else if(row > -1){
+        e.preventDefault();
+        startDrag('row', row, e);
+      }
+    });
+
+    handle.addEventListener('mousedown', e => {
+      e.preventDefault();
+      startDrag('table', null, e);
+    });
+
+    table.addEventListener('dblclick', e => {
+      const rect = table.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const col = getColEdge(table, x);
+      const row = getRowEdge(table, y);
+      if(col > -1) autoFitCol(table, col);
+      else if(row > -1) autoFitRow(table, row);
+    });
+
+    function startDrag(type, index, e){
+      drag = { type, index, startX: e.clientX, startY: e.clientY };
+      if(type === 'table'){
+        drag.startWidth = table.offsetWidth;
+        drag.startHeight = table.offsetHeight;
+      } else if(type === 'col'){
+        drag.startSize = getColWidth(table, index);
+      } else {
+        drag.startSize = getRowHeight(table, index);
+      }
+      guide = document.createElement('div');
+      guide.className = 'resize-guide ' + (type==='col'?'vertical':'horizontal');
+      table.appendChild(guide);
+      document.body.style.userSelect = 'none';
+    }
+
+    document.addEventListener('mousemove', e => {
+      if(!drag) return;
+      if(drag.type === 'col'){
+        const dx = e.clientX - drag.startX;
+        if(e.altKey){
+          const i = drag.index;
+          const leftW = getColWidth(table, i);
+          const rightW = getColWidth(table, i+1);
+          setColWidth(table, i, snap(Math.max(30, leftW + dx/2)));
+          setColWidth(table, i+1, snap(Math.max(30, rightW - dx/2)));
+        } else if(e.shiftKey){
+          const ratio = (drag.startSize + dx) / drag.startSize;
+          const cols = table.rows[0].cells.length;
+          for(let c=0;c<cols;c++){
+            let w = getColWidth(table,c);
+            if(c===drag.index) w = drag.startSize + dx;
+            else w = w * ratio;
+            setColWidth(table,c,snap(Math.max(30,w)));
+          }
+        } else {
+          const newW = snap(Math.max(30, drag.startSize + dx));
+          setColWidth(table, drag.index, newW);
+        }
+        guide.style.left = getColRight(table, drag.index) + 'px';
+      } else if(drag.type === 'row'){
+        const dy = e.clientY - drag.startY;
+        if(e.altKey){
+          const i = drag.index;
+          const topH = getRowHeight(table,i);
+          const botH = getRowHeight(table,i+1);
+          setRowHeight(table,i,snap(Math.max(24, topH + dy/2)));
+          setRowHeight(table,i+1,snap(Math.max(24, botH - dy/2)));
+        } else if(e.shiftKey){
+          const ratio = (drag.startSize + dy) / drag.startSize;
+          const rows = table.rows.length;
+          for(let r=0;r<rows;r++){
+            let h = getRowHeight(table,r);
+            if(r===drag.index) h = drag.startSize + dy;
+            else h = h * ratio;
+            setRowHeight(table,r,snap(Math.max(24,h)));
+          }
+        } else {
+          const newH = snap(Math.max(24, drag.startSize + dy));
+          setRowHeight(table, drag.index, newH);
+        }
+        guide.style.top = getRowBottom(table, drag.index) + 'px';
+      } else {
+        const dx = e.clientX - drag.startX;
+        const dy = e.clientY - drag.startY;
+        table.style.width = snap(Math.max(60, drag.startWidth + dx)) + 'px';
+        table.style.height = snap(Math.max(40, drag.startHeight + dy)) + 'px';
+      }
+    });
+
+    document.addEventListener('mouseup', () => {
+      if(!drag) return;
+      drag = null;
+      document.body.style.userSelect = '';
+      if(guide){ guide.remove(); guide = null; }
+      table.style.cursor = '';
+    });
+  }
+
+  function getColEdge(table, x){
+    const row = table.rows[0];
+    if(!row) return -1;
+    let left = 0;
+    for(let i=0;i<row.cells.length;i++){
+      left += row.cells[i].offsetWidth;
+      if(Math.abs(x-left)<=4) return i;
+    }
+    return -1;
+  }
+  function getRowEdge(table, y){
+    let top=0;
+    for(let i=0;i<table.rows.length;i++){
+      top += table.rows[i].offsetHeight;
+      if(Math.abs(y-top)<=4) return i;
+    }
+    return -1;
+  }
+  function getColWidth(table,i){
+    const cell = table.rows[0].cells[i];
+    return cell ? cell.offsetWidth : 0;
+  }
+  function setColWidth(table,i,w){
+    for(const row of table.rows){
+      const cell = row.cells[i];
+      if(cell) cell.style.width = w + 'px';
+    }
+  }
+  function getColRight(table,i){
+    const row = table.rows[0];
+    let right = 0;
+    for(let c=0;c<=i;c++) right += row.cells[c].offsetWidth;
+    return right;
+  }
+  function getRowHeight(table,i){
+    const row = table.rows[i];
+    return row ? row.offsetHeight : 0;
+  }
+  function setRowHeight(table,i,h){
+    const row = table.rows[i];
+    if(row) row.style.height = h + 'px';
+  }
+  function getRowBottom(table,i){
+    let bottom = 0;
+    for(let r=0;r<=i;r++) bottom += table.rows[r].offsetHeight;
+    return bottom;
+  }
+  function autoFitCol(table,i){
+    let max = 0;
+    for(const row of table.rows){
+      const cell = row.cells[i];
+      if(cell){
+        const prev = cell.style.width;
+        cell.style.width = 'auto';
+        const w = cell.offsetWidth;
+        if(w>max) max=w;
+        cell.style.width = prev;
+      }
+    }
+    setColWidth(table,i,snap(max));
+  }
+  function autoFitRow(table,i){
+    const row = table.rows[i];
+    if(row){
+      const prev = row.style.height;
+      row.style.height = 'auto';
+      const h = row.offsetHeight;
+      row.style.height = prev;
+      setRowHeight(table,i,snap(h));
+    }
+  }
+
+  window.initResizableTables = initResizableTables;
+})();


### PR DESCRIPTION
## Summary
- add standalone demo with three resizable tables
- implement vanilla JS table resizing (corner handle, column/row drag, auto-fit)
- document component usage in README

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b785132bd8832c9d79782d79e18c2d