### PR TITLE
fix: remove editor handles from printed output

### DIFF
--- a/index.css
+++ b/index.css
@@ -838,6 +838,19 @@ table.resizable-table .table-resize-handle {
                 page-break-inside: avoid;
                 break-inside: avoid;
             }
+            /* Hide table resize handles and allow tables to reflow when printing */
+            .table-resize-handle {
+                display: none !important;
+            }
+            table.resizable-table,
+            table.resizable-table td,
+            table.resizable-table th {
+                width: auto !important;
+                height: auto !important;
+                max-width: 100% !important;
+                page-break-inside: auto !important;
+                break-inside: auto !important;
+            }
             #print-index {
                 page-break-after: always;
             }


### PR DESCRIPTION
## Summary
- Hide resizable-table handles during printing
- Allow resizable tables to auto-fit and break normally in print

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b79ab1ccb0832c9ad92bd116d58b84