### PR TITLE
Remove table resize artifacts in print output

### DIFF
--- a/index.css
+++ b/index.css
@@ -838,6 +838,16 @@ table.resizable-table .table-resize-handle {
                 page-break-inside: avoid;
                 break-inside: avoid;
             }
+            /* Reset resizable tables for printing */
+            table.resizable-table {
+                width: 100% !important;
+                height: auto !important;
+                table-layout: auto !important;
+                page-break-inside: auto;
+            }
+            table.resizable-table .table-resize-handle {
+                display: none !important;
+            }
             #print-index {
                 page-break-after: always;
             }

--- a/index.js
+++ b/index.js
@@ -1064,6 +1064,7 @@ document.addEventListener('DOMContentLoaded', function () {
         subNoteToolbar.appendChild(createSNButton('Imprimir o Guardar como PDF', '💾', null, null, () => {
             const printArea = getElem('print-area');
             printArea.innerHTML = `<div>${subNoteEditor.innerHTML}</div>`;
+            cleanupResizableTables(printArea);
             window.print();
         }));
     }
@@ -2779,6 +2780,7 @@ document.addEventListener('DOMContentLoaded', function () {
         const printBtn = createButton('Imprimir o Guardar como PDF', '💾', null, null, () => {
              const printArea = getElem('print-area');
              printArea.innerHTML = `<div>${notesEditor.innerHTML}</div>`;
+             cleanupResizableTables(printArea);
              window.print();
         });
         editorToolbar.appendChild(printBtn);
@@ -3750,6 +3752,19 @@ document.addEventListener('DOMContentLoaded', function () {
         table.dataset.resizableInitialized = 'true';
     }
 
+    function cleanupResizableTables(root) {
+        root.querySelectorAll('.table-resize-handle').forEach(h => h.remove());
+        root.querySelectorAll('table.resizable-table').forEach(table => {
+            table.style.width = '';
+            table.style.height = '';
+            table.style.cursor = '';
+            table.querySelectorAll('td, th').forEach(cell => {
+                cell.style.width = '';
+                cell.style.height = '';
+            });
+        });
+    }
+
     function renderNotesList() {
         notesList.innerHTML = '';
         if (currentNotesArray.length === 0) {
@@ -4383,6 +4398,7 @@ document.addEventListener('DOMContentLoaded', function () {
             return;
         }
 
+        cleanupResizableTables(printArea);
         window.print();
     }
 
@@ -4489,6 +4505,7 @@ document.addEventListener('DOMContentLoaded', function () {
             return;
         }
 
+        cleanupResizableTables(printArea);
         window.print();
     }
 


### PR DESCRIPTION
## Summary
- Oculta los controles de redimensionado y restablece tamaño automático en las tablas al imprimir
- Limpia las tablas redimensionables antes de generar PDF para evitar espacios en blanco

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b79ab1ccb0832c9ad92bd116d58b84