### PR TITLE
fix: limpiar tablas redimensionables al imprimir

### DIFF
--- a/index.css
+++ b/index.css
@@ -841,6 +841,19 @@ table.resizable-table .table-resize-handle {
             #print-index {
                 page-break-after: always;
             }
+            table.resizable-table {
+                width: auto !important;
+                height: auto !important;
+                page-break-inside: auto !important;
+            }
+            table.resizable-table td,
+            table.resizable-table th {
+                width: auto !important;
+                height: auto !important;
+            }
+            table.resizable-table .table-resize-handle {
+                display: none !important;
+            }
         }
 
 /* Note callout styles */

--- a/index.js
+++ b/index.js
@@ -1064,6 +1064,7 @@ document.addEventListener('DOMContentLoaded', function () {
         subNoteToolbar.appendChild(createSNButton('Imprimir o Guardar como PDF', '💾', null, null, () => {
             const printArea = getElem('print-area');
             printArea.innerHTML = `<div>${subNoteEditor.innerHTML}</div>`;
+            sanitizeTablesForPrint(printArea);
             window.print();
         }));
     }
@@ -2779,6 +2780,7 @@ document.addEventListener('DOMContentLoaded', function () {
         const printBtn = createButton('Imprimir o Guardar como PDF', '💾', null, null, () => {
              const printArea = getElem('print-area');
              printArea.innerHTML = `<div>${notesEditor.innerHTML}</div>`;
+             sanitizeTablesForPrint(printArea);
              window.print();
         });
         editorToolbar.appendChild(printBtn);
@@ -4239,7 +4241,23 @@ document.addEventListener('DOMContentLoaded', function () {
         // Apply current zoom after updating image
         applyZoom();
     }
-    
+
+    function sanitizeTablesForPrint(container) {
+        container.querySelectorAll('.table-resize-handle').forEach(handle => handle.remove());
+        container.querySelectorAll('table').forEach(table => {
+            table.style.width = '';
+            table.style.height = '';
+            table.removeAttribute('width');
+            table.removeAttribute('height');
+            table.querySelectorAll('td, th').forEach(cell => {
+                cell.style.width = '';
+                cell.style.height = '';
+                cell.removeAttribute('width');
+                cell.removeAttribute('height');
+            });
+        });
+    }
+
     async function handlePrintAll() {
         await db.connect();
         const printArea = getElem('print-area');
@@ -4363,6 +4381,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     const note = topicData.notes[0];
                     const noteContent = document.createElement('div');
                     noteContent.innerHTML = note.content;
+                    sanitizeTablesForPrint(noteContent);
                     noteContent.querySelectorAll('a.subnote-link, a.postit-link, a.gallery-link').forEach(link => {
                         link.outerHTML = `<span>${link.innerHTML}</span>`;
                     });
@@ -4383,6 +4402,7 @@ document.addEventListener('DOMContentLoaded', function () {
             return;
         }
 
+        sanitizeTablesForPrint(printArea);
         window.print();
     }
 
@@ -4468,6 +4488,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 const note = topicData.notes[0];
                 const noteContent = document.createElement('div');
                 noteContent.innerHTML = note.content;
+                sanitizeTablesForPrint(noteContent);
                 // Sanitize links for printing
                 // Convert sub-note and post-it links back to plain text for printing
                 noteContent.querySelectorAll('a.subnote-link, a.postit-link, a.gallery-link').forEach(link => {
@@ -4489,6 +4510,7 @@ document.addEventListener('DOMContentLoaded', function () {
             return;
         }
 
+        sanitizeTablesForPrint(printArea);
         window.print();
     }
 


### PR DESCRIPTION
## Summary
- Oculta y reinicia dimensiones de tablas redimensionables durante la impresión
- Elimina `table-resize-handle` y estilos de tamaño antes de generar PDF

## Testing
- `npm test` *(missing script: test)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b79ab1ccb0832c9ad92bd116d58b84