### PR TITLE
Mejoras de selección y manejo de imágenes

### DIFF
--- a/editor-enhancements.js
+++ b/editor-enhancements.js
@@ -83,7 +83,13 @@ export function setupAdvancedEditing(editor) {
   }
 
   let dragLine = null;
+
+  // Allow dragging lines only when holding Alt to avoid interfering with text selection.
   editor.addEventListener('dragstart', e => {
+    if (!e.altKey) {
+      e.preventDefault();
+      return;
+    }
     const line = e.target.closest('p');
     if (!line) return;
     dragLine = line;
@@ -102,10 +108,20 @@ export function setupAdvancedEditing(editor) {
     dragLine = null;
   });
 
-  editor.querySelectorAll('p').forEach(p => p.setAttribute('draggable', 'true'));
+  // Toggle draggable attribute based on Alt key usage
+  editor.addEventListener('mousedown', e => {
+    const p = e.target.closest('p');
+    if (!p) return;
+    p.setAttribute('draggable', e.altKey ? 'true' : 'false');
+  });
+  document.addEventListener('mouseup', () => {
+    editor.querySelectorAll('p').forEach(p => p.setAttribute('draggable', 'false'));
+  });
+
+  editor.querySelectorAll('p').forEach(p => p.setAttribute('draggable', 'false'));
   const observer = new MutationObserver(() => {
     editor.querySelectorAll('p').forEach(p => {
-      if (!p.getAttribute('draggable')) p.setAttribute('draggable', 'true');
+      p.setAttribute('draggable', 'false');
     });
   });
   observer.observe(editor, { childList: true, subtree: true });

--- a/index.css
+++ b/index.css
@@ -158,7 +158,12 @@
         #notes-editor { border: 1px solid var(--border-color); padding: 12px; flex-grow: 1; overflow-y: auto; border-bottom-left-radius: 0.5rem; border-bottom-right-radius: 0.5rem; line-height: 1.6; background-color: var(--bg-secondary); }
         #notes-editor:focus { outline: none; }
         #notes-editor img { max-width: 100%; height: auto; border-radius: 0.5rem; cursor: pointer; }
-        #notes-editor img.selected-for-resize { outline: 2px solid var(--btn-primary-bg); }
+        #notes-editor img.selected-for-resize {
+            outline: 2px solid var(--btn-primary-bg);
+            resize: both;
+            overflow: auto;
+            display: inline-block;
+        }
 
         /* Display multiple images in a row */
         #notes-editor .image-row {
@@ -184,7 +189,12 @@
         }
         #subnote-editor:focus { outline: none; }
         #subnote-editor img { max-width: 100%; height: auto; border-radius: 0.5rem; cursor: pointer; }
-        #subnote-editor img.selected-for-resize { outline: 2px solid var(--btn-primary-bg); }
+        #subnote-editor img.selected-for-resize {
+            outline: 2px solid var(--btn-primary-bg);
+            resize: both;
+            overflow: auto;
+            display: inline-block;
+        }
 
         /* Smaller buttons for the sub-note action bar */
         #subnote-modal-actions button {
@@ -400,9 +410,11 @@ table.resizable-table .table-resize-handle {
 /* Floating image styles */
 .float-image {
     display: block;
-    max-width: 250px;
+    max-width: 100%;
     margin: 0 1rem 1rem 0;
     cursor: default;
+    resize: both;
+    overflow: auto;
 }
 .float-image.float-left {
     float: left;

--- a/index.js
+++ b/index.js
@@ -1391,6 +1391,7 @@ document.addEventListener('DOMContentLoaded', function () {
         // Use relative positioning so that text flows around normally
         fig.style.position = fig.style.position || 'relative';
         fig.addEventListener('mousedown', (e) => {
+            if (!e.altKey) return; // Only drag with Alt to avoid interfering with resizing
             isDragging = true;
             const rect = fig.getBoundingClientRect();
             offsetX = e.clientX - rect.left;
@@ -1474,6 +1475,7 @@ document.addEventListener('DOMContentLoaded', function () {
         if (existingFig) {
             existingFig.classList.remove('float-left', 'float-right');
             existingFig.classList.add(`float-${align}`);
+            enableDragForFloatingImage(existingFig);
             return;
         }
         // Crear figure y mover la imagen dentro
@@ -1482,6 +1484,7 @@ document.addEventListener('DOMContentLoaded', function () {
         fig.contentEditable = 'false';
         img.parentNode.insertBefore(fig, img);
         fig.appendChild(img);
+        enableDragForFloatingImage(fig);
         // Insertar espacio NBSP para que el cursor siga después del figure
         const spacer = document.createTextNode('\u00A0');
         fig.parentNode.insertBefore(spacer, fig.nextSibling);


### PR DESCRIPTION
## Resumen
- Reducir sensibilidad de arrastre de párrafos: solo se arrastran al mantener Alt
- Permitir redimensionar imágenes desde sus bordes y esquinas
- Habilitar arrastre con Alt en imágenes flotantes con estilo "cuadrado"

## Pruebas
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7af70551c832c8dbc6c4b4dcdc10a