### PR TITLE
Improve text selection and image placement

### DIFF
--- a/editor-enhancements.js
+++ b/editor-enhancements.js
@@ -83,6 +83,18 @@ export function setupAdvancedEditing(editor) {
   }
 
   let dragLine = null;
+  editor.addEventListener('mousedown', e => {
+    if (e.altKey) return;
+    const line = e.target.closest('p');
+    if (e.ctrlKey && line) {
+      line.setAttribute('draggable', 'true');
+    } else {
+      editor.querySelectorAll('p[draggable="true"]').forEach(p => p.setAttribute('draggable', 'false'));
+    }
+  });
+  editor.addEventListener('mouseup', () => {
+    editor.querySelectorAll('p[draggable="true"]').forEach(p => p.setAttribute('draggable', 'false'));
+  });
   editor.addEventListener('dragstart', e => {
     const line = e.target.closest('p');
     if (!line) return;
@@ -102,10 +114,10 @@ export function setupAdvancedEditing(editor) {
     dragLine = null;
   });
 
-  editor.querySelectorAll('p').forEach(p => p.setAttribute('draggable', 'true'));
+  editor.querySelectorAll('p').forEach(p => p.setAttribute('draggable', 'false'));
   const observer = new MutationObserver(() => {
     editor.querySelectorAll('p').forEach(p => {
-      if (!p.getAttribute('draggable')) p.setAttribute('draggable', 'true');
+      if (!p.getAttribute('draggable')) p.setAttribute('draggable', 'false');
     });
   });
   observer.observe(editor, { childList: true, subtree: true });

--- a/image-resize.js
+++ b/image-resize.js
@@ -1,0 +1,54 @@
+export function makeImageResizable(fig) {
+  if (!fig || fig.dataset.resizable === 'true') return;
+  fig.dataset.resizable = 'true';
+  fig.style.position = fig.style.position || 'relative';
+  const img = fig.querySelector('img');
+  const dirs = ['n','e','s','w','nw','ne','sw','se'];
+  let activeDir = null;
+  let startX = 0, startY = 0, startW = 0, startH = 0;
+
+  function startResize(e, dir) {
+    e.preventDefault();
+    e.stopPropagation();
+    activeDir = dir;
+    startX = e.clientX;
+    startY = e.clientY;
+    startW = fig.offsetWidth;
+    startH = fig.offsetHeight;
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', stopResize);
+  }
+
+  function onMove(e) {
+    if (!activeDir) return;
+    const dx = e.clientX - startX;
+    const dy = e.clientY - startY;
+    let newW = startW;
+    let newH = startH;
+    if (activeDir.includes('e')) newW = startW + dx;
+    if (activeDir.includes('w')) newW = startW - dx;
+    if (activeDir.includes('s')) newH = startH + dy;
+    if (activeDir.includes('n')) newH = startH - dy;
+    newW = Math.max(30, newW);
+    newH = Math.max(30, newH);
+    fig.style.width = newW + 'px';
+    fig.style.height = newH + 'px';
+    if (img) {
+      img.style.width = '100%';
+      img.style.height = '100%';
+    }
+  }
+
+  function stopResize() {
+    activeDir = null;
+    document.removeEventListener('mousemove', onMove);
+    document.removeEventListener('mouseup', stopResize);
+  }
+
+  dirs.forEach(dir => {
+    const handle = document.createElement('div');
+    handle.className = `img-resize-handle ${dir}`;
+    handle.addEventListener('mousedown', e => startResize(e, dir));
+    fig.appendChild(handle);
+  });
+}

--- a/index.css
+++ b/index.css
@@ -400,9 +400,9 @@ table.resizable-table .table-resize-handle {
 /* Floating image styles */
 .float-image {
     display: block;
-    max-width: 250px;
     margin: 0 1rem 1rem 0;
     cursor: default;
+    position: relative;
 }
 .float-image.float-left {
     float: left;
@@ -415,6 +415,60 @@ table.resizable-table .table-resize-handle {
     height: auto;
     display: block;
     border-radius: 0.25rem;
+}
+
+.float-image .img-resize-handle {
+    position: absolute;
+    width: 8px;
+    height: 8px;
+    background: #3b82f6;
+    border: 1px solid #fff;
+    box-sizing: border-box;
+    z-index: 10;
+}
+.float-image .img-resize-handle.n {
+    top: -4px;
+    left: 50%;
+    transform: translateX(-50%);
+    cursor: ns-resize;
+}
+.float-image .img-resize-handle.s {
+    bottom: -4px;
+    left: 50%;
+    transform: translateX(-50%);
+    cursor: ns-resize;
+}
+.float-image .img-resize-handle.e {
+    right: -4px;
+    top: 50%;
+    transform: translateY(-50%);
+    cursor: ew-resize;
+}
+.float-image .img-resize-handle.w {
+    left: -4px;
+    top: 50%;
+    transform: translateY(-50%);
+    cursor: ew-resize;
+}
+.float-image .img-resize-handle.nw {
+    top: -4px;
+    left: -4px;
+    cursor: nwse-resize;
+}
+.float-image .img-resize-handle.ne {
+    top: -4px;
+    right: -4px;
+    cursor: nesw-resize;
+}
+.float-image .img-resize-handle.sw {
+    bottom: -4px;
+    left: -4px;
+    cursor: nesw-resize;
+}
+.float-image .img-resize-handle.se {
+    bottom: -4px;
+    right: -4px;
+    cursor: nwse-resize;
 }
 
 /* Table size selection grid */

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ import { setupKeyboardShortcuts } from './shortcuts.js';
 import { setupCloudIntegration } from './cloud-sync.js';
 import { setupAdvancedEditing } from './editor-enhancements.js';
 import { improveText, askNotesQuestion } from './ai-tools.js';
+import { makeImageResizable } from './image-resize.js';
 
 // --- IndexedDB Helper ---
 // NOTE: The IndexedDB helper has been moved into db.js.  The following
@@ -1353,6 +1354,8 @@ document.addEventListener('DOMContentLoaded', function () {
         img.src = url;
         img.alt = '';
         fig.appendChild(img);
+        enableDragForFloatingImage(fig);
+        makeImageResizable(fig);
         // Insert the figure at the current caret position
         const sel = window.getSelection();
         if (sel && sel.rangeCount > 0) {
@@ -1474,6 +1477,8 @@ document.addEventListener('DOMContentLoaded', function () {
         if (existingFig) {
             existingFig.classList.remove('float-left', 'float-right');
             existingFig.classList.add(`float-${align}`);
+            enableDragForFloatingImage(existingFig);
+            makeImageResizable(existingFig);
             return;
         }
         // Crear figure y mover la imagen dentro
@@ -1482,6 +1487,8 @@ document.addEventListener('DOMContentLoaded', function () {
         fig.contentEditable = 'false';
         img.parentNode.insertBefore(fig, img);
         fig.appendChild(img);
+        enableDragForFloatingImage(fig);
+        makeImageResizable(fig);
         // Insertar espacio NBSP para que el cursor siga después del figure
         const spacer = document.createTextNode('\u00A0');
         fig.parentNode.insertBefore(spacer, fig.nextSibling);
@@ -5322,6 +5329,10 @@ document.addEventListener('DOMContentLoaded', function () {
         setupAdvancedSearchReplace();
         setupKeyboardShortcuts();
         setupAdvancedEditing(notesEditor);
+        notesEditor.querySelectorAll('figure.float-image').forEach(fig => {
+            enableDragForFloatingImage(fig);
+            makeImageResizable(fig);
+        });
         setupCloudIntegration();
     }
 


### PR DESCRIPTION
## Summary
- Require holding Ctrl to drag paragraphs so text selection isn't misinterpreted as moving lines
- Allow floating images with drag handles to be resized from edges or corners
- Initialize existing floating images with draggable and resizable behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7af70551c832c8dbc6c4b4dcdc10a