### PR TITLE
feat: font and line tools with undo fixes

### DIFF
--- a/index.css
+++ b/index.css
@@ -63,7 +63,7 @@
         }
 
 
-        body { font-family: 'Inter', sans-serif; background-color: var(--bg-primary); color: var(--text-primary); }
+        body { font-family: 'San Francisco', 'Inter', sans-serif; background-color: var(--bg-primary); color: var(--text-primary); }
 
         .filter-btn.active {
             box-shadow: 0 0 0 2px #0ea5e9, 0 0 0 4px var(--bg-secondary);
@@ -865,6 +865,10 @@ table.resizable-table .table-resize-handle {
 .indent-3 { margin-left: 3rem; }
 .indent-4 { margin-left: 4rem; }
 .indent-5 { margin-left: 5rem; }
+
+hr.hr-solid { border-top: 1px solid var(--text-primary); }
+hr.hr-dotted { border-top: 1px dotted var(--text-primary); }
+hr.hr-dashed { border-top: 1px dashed var(--text-primary); }
 .note-resizable {
     resize: horizontal;
     overflow: auto;


### PR DESCRIPTION
## Summary
- add font selector with San Francisco default and zoom options
- support inserting solid, dotted, or dashed horizontal lines
- track drag and indent operations in custom undo history

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb72a3f5e4832ca5dd8f268e4d2fb8