### PR TITLE
Move block drag toggle and add wide view option

### DIFF
--- a/index.css
+++ b/index.css
@@ -106,6 +106,7 @@
         .modal-overlay.visible .modal-content { transform: translateY(0); }
         
         .notes-modal-content { max-width: 900px; height: 95vh; max-height: 95vh; padding: 0; }
+        .notes-modal-content.full-width { max-width: none; width: 95vw; }
 
         #subnote-modal .notes-modal-content {
             padding: 1rem;
@@ -291,6 +292,11 @@
         .toolbar-btn:hover { background-color: var(--bg-tertiary); }
         .toolbar-btn.active { background-color: var(--bg-tertiary); }
         .toolbar-btn.active:hover { background-color: var(--bg-tertiary); }
+        #toggle-block-drag-btn.active,
+        #toggle-fullwidth-btn.active {
+            background-color: var(--btn-primary-bg);
+            color: var(--btn-primary-text);
+        }
         .toolbar-select {
             font-size: 12px;
             background-color: var(--bg-secondary);

--- a/index.html
+++ b/index.html
@@ -371,6 +371,10 @@
                             <button id="toggle-html-paste-btn" class="toolbar-btn" title="Permitir pegado con formato HTML">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-code w-5 h-5"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
                             </button>
+                            <button id="toggle-block-drag-btn" class="toolbar-btn" title="Mover bloques">✋</button>
+                            <button id="toggle-fullwidth-btn" class="toolbar-btn" title="Vista amplia">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-maximize-2 w-5 h-5"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg>
+                            </button>
                             <button id="note-info-btn" class="toolbar-btn" title="Información de la nota">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-info w-5 h-5"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
                             </button>

--- a/index.js
+++ b/index.js
@@ -524,8 +524,12 @@ document.addEventListener('DOMContentLoaded', function () {
     const subNoteTitle = getElem('subnote-title');
     const subNoteEditor = getElem('subnote-editor');
     const toggleHtmlPasteBtn = getElem('toggle-html-paste-btn');
+    const blockDragBtn = getElem('toggle-block-drag-btn');
+    const toggleFullwidthBtn = getElem('toggle-fullwidth-btn');
+    const notesModalContent = notesModal.querySelector('.notes-modal-content');
 
     let htmlPasteEnabled = false;
+    let fullWidthEnabled = false;
 
     function sanitizeHtml(html) {
         const div = document.createElement('div');
@@ -538,6 +542,14 @@ document.addEventListener('DOMContentLoaded', function () {
         toggleHtmlPasteBtn.addEventListener('click', () => {
             htmlPasteEnabled = !htmlPasteEnabled;
             toggleHtmlPasteBtn.classList.toggle('active', htmlPasteEnabled);
+        });
+    }
+
+    if (toggleFullwidthBtn && notesModalContent) {
+        toggleFullwidthBtn.addEventListener('click', () => {
+            fullWidthEnabled = !fullWidthEnabled;
+            toggleFullwidthBtn.classList.toggle('active', fullWidthEnabled);
+            notesModalContent.classList.toggle('full-width', fullWidthEnabled);
         });
     }
 
@@ -2172,7 +2184,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
         const toggleBlockDrag = () => {
             blockDragEnabled = !blockDragEnabled;
-            dragBtn.classList.toggle('active', blockDragEnabled);
+            if (blockDragBtn) blockDragBtn.classList.toggle('active', blockDragEnabled);
             if (blockDragEnabled) {
                 enableBlockDragging();
             } else {
@@ -2180,8 +2192,9 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         };
 
-        const dragBtn = createButton('Mover bloques', '✋', null, null, toggleBlockDrag);
-        editorToolbar.appendChild(dragBtn);
+        if (blockDragBtn) {
+            blockDragBtn.addEventListener('click', toggleBlockDrag);
+        }
 
         const adjustIndent = (delta, root) => {
             const sel = window.getSelection();
@@ -4057,9 +4070,12 @@ document.addEventListener('DOMContentLoaded', function () {
 
         const currentTab = openNoteTabs.find(t => t.id === activeTabId);
         if (currentTab) currentTab.activeIndex = index;
-        
+
         notesModalTitle.textContent = note.title || `Nota ${index + 1}`;
         notesEditor.innerHTML = note.content || '<p><br></p>';
+        blockDragEnabled = false;
+        disableBlockDragging();
+        if (blockDragBtn) blockDragBtn.classList.remove('active');
         notesEditor.querySelectorAll('table').forEach(initTableResize);
 
         renderNotesList();


### PR DESCRIPTION
## Summary
- Reubicado el botón para mover bloques junto al control de pegado HTML.
- El botón de mover bloques ahora inicia deshabilitado y marca claramente cuando está activo.
- Añadido botón para ampliar el editor casi a pantalla completa y estilos asociados.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb799d28f8832cbae972fd26918922