### PR TITLE
Move block drag toggle and add fullscreen mode

### DIFF
--- a/index.css
+++ b/index.css
@@ -107,6 +107,11 @@
         
         .notes-modal-content { max-width: 900px; height: 95vh; max-height: 95vh; padding: 0; }
 
+        .notes-modal-content.fullscreen { max-width: 100vw; width: 100vw; height: 95vh; }
+        .notes-modal-content.fullscreen #notes-side-panel,
+        .notes-modal-content.fullscreen .resizer-e-panel { display: none; }
+        .notes-modal-content.fullscreen #notes-main-content { flex: 1; }
+
         #subnote-modal .notes-modal-content {
             padding: 1rem;
         }

--- a/index.css
+++ b/index.css
@@ -107,10 +107,18 @@
         
         .notes-modal-content { max-width: 900px; height: 95vh; max-height: 95vh; padding: 0; }
 
-        .notes-modal-content.fullscreen { max-width: 100vw; width: 100vw; height: 95vh; }
+        .notes-modal-content.fullscreen { max-width: 100vw; width: 100vw; height: 95vh; background: #fff; }
         .notes-modal-content.fullscreen #notes-side-panel,
         .notes-modal-content.fullscreen .resizer-e-panel { display: none; }
-        .notes-modal-content.fullscreen #notes-main-content { flex: 1; }
+        .notes-modal-content.fullscreen #notes-main-content { flex: 0 0 auto; }
+        .notes-modal-content.fullscreen #notes-editor {
+            background: #fff;
+            border: 1px solid var(--border-color);
+            background-image:
+                linear-gradient(to right, var(--border-color) 1px, transparent 1px),
+                linear-gradient(to bottom, var(--border-color) 1px, transparent 1px);
+            background-size: 20px 20px;
+        }
 
         #subnote-modal .notes-modal-content {
             padding: 1rem;

--- a/index.css
+++ b/index.css
@@ -114,10 +114,6 @@
         .notes-modal-content.fullscreen #notes-editor {
             background: #fff;
             border: 1px solid var(--border-color);
-            background-image:
-                linear-gradient(to right, var(--border-color) 1px, transparent 1px),
-                linear-gradient(to bottom, var(--border-color) 1px, transparent 1px);
-            background-size: 20px 20px;
         }
 
         #subnote-modal .notes-modal-content {

--- a/index.html
+++ b/index.html
@@ -371,6 +371,10 @@
                             <button id="toggle-html-paste-btn" class="toolbar-btn" title="Permitir pegado con formato HTML">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-code w-5 h-5"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
                             </button>
+                            <button id="toggle-block-drag-btn" class="toolbar-btn" title="Mover bloques">✋</button>
+                            <button id="toggle-fullscreen-btn" class="toolbar-btn" title="Pantalla completa">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-maximize-2 w-5 h-5"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><polyline points="21 15 21 21 15 21"/><polyline points="3 9 3 3 9 3"/></svg>
+                            </button>
                             <button id="note-info-btn" class="toolbar-btn" title="Información de la nota">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-info w-5 h-5"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
                             </button>

--- a/index.js
+++ b/index.js
@@ -102,6 +102,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const notesModalTitle = getElem('notes-modal-title');
     const notesEditor = getElem('notes-editor');
     const editorToolbar = notesModal.querySelector('.editor-toolbar');
+    const notesModalContent = notesModal.querySelector('.notes-modal-content');
     const saveNoteBtn = getElem('save-note-btn');
     const saveAndCloseNoteBtn = getElem('save-and-close-note-btn');
     const cancelNoteBtn = getElem('cancel-note-btn');
@@ -235,6 +236,7 @@ document.addEventListener('DOMContentLoaded', function () {
     let activeTabId = null;
     let tabPosition = 'top';
     let blockDragEnabled = false;
+    let fullscreenEnabled = false;
     let draggedBlock = null;
 
     if (minimizeNoteBtn && restoreNoteBtn) {
@@ -524,6 +526,8 @@ document.addEventListener('DOMContentLoaded', function () {
     const subNoteTitle = getElem('subnote-title');
     const subNoteEditor = getElem('subnote-editor');
     const toggleHtmlPasteBtn = getElem('toggle-html-paste-btn');
+    const dragBtn = getElem('toggle-block-drag-btn');
+    const fullscreenBtn = getElem('toggle-fullscreen-btn');
 
     let htmlPasteEnabled = false;
 
@@ -2172,7 +2176,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
         const toggleBlockDrag = () => {
             blockDragEnabled = !blockDragEnabled;
-            dragBtn.classList.toggle('active', blockDragEnabled);
+            dragBtn?.classList.toggle('active', blockDragEnabled);
             if (blockDragEnabled) {
                 enableBlockDragging();
             } else {
@@ -2180,8 +2184,29 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         };
 
-        const dragBtn = createButton('Mover bloques', '✋', null, null, toggleBlockDrag);
-        editorToolbar.appendChild(dragBtn);
+        const toggleFullscreen = () => {
+            fullscreenEnabled = !fullscreenEnabled;
+            notesModalContent?.classList.toggle('fullscreen', fullscreenEnabled);
+            fullscreenBtn?.classList.toggle('active', fullscreenEnabled);
+        };
+
+        if (dragBtn) {
+            dragBtn.addEventListener('click', toggleBlockDrag);
+        }
+        if (fullscreenBtn) {
+            fullscreenBtn.addEventListener('click', toggleFullscreen);
+        }
+
+        const resetEditorModes = () => {
+            blockDragEnabled = false;
+            if (dragBtn) dragBtn.classList.remove('active');
+            disableBlockDragging();
+            fullscreenEnabled = false;
+            if (fullscreenBtn) fullscreenBtn.classList.remove('active');
+            if (notesModalContent) notesModalContent.classList.remove('fullscreen');
+        };
+
+        resetEditorModes();
 
         const adjustIndent = (delta, root) => {
             const sel = window.getSelection();
@@ -3422,6 +3447,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
     function hideModal(modal) {
         modal.classList.remove('visible');
+        if (modal === notesModal) {
+            resetEditorModes();
+        }
     }
 
     function showAlert(message, title = "Aviso") {

--- a/index.js
+++ b/index.js
@@ -237,6 +237,7 @@ document.addEventListener('DOMContentLoaded', function () {
     let tabPosition = 'top';
     let blockDragEnabled = false;
     let fullscreenEnabled = false;
+    let savedEditorWidth = 0;
     let draggedBlock = null;
 
     if (minimizeNoteBtn && restoreNoteBtn) {
@@ -2185,6 +2186,18 @@ document.addEventListener('DOMContentLoaded', function () {
         };
 
         const toggleFullscreen = () => {
+            if (!fullscreenEnabled) {
+                if (notesMainContent) {
+                    savedEditorWidth = notesMainContent.offsetWidth;
+                    notesMainContent.style.maxWidth = savedEditorWidth + 'px';
+                    notesMainContent.style.margin = '0 auto';
+                }
+            } else {
+                if (notesMainContent) {
+                    notesMainContent.style.maxWidth = '';
+                    notesMainContent.style.margin = '';
+                }
+            }
             fullscreenEnabled = !fullscreenEnabled;
             notesModalContent?.classList.toggle('fullscreen', fullscreenEnabled);
             fullscreenBtn?.classList.toggle('active', fullscreenEnabled);
@@ -2204,6 +2217,11 @@ document.addEventListener('DOMContentLoaded', function () {
             fullscreenEnabled = false;
             if (fullscreenBtn) fullscreenBtn.classList.remove('active');
             if (notesModalContent) notesModalContent.classList.remove('fullscreen');
+            if (notesMainContent) {
+                notesMainContent.style.maxWidth = '';
+                notesMainContent.style.margin = '';
+            }
+            savedEditorWidth = 0;
         };
 
         resetEditorModes();


### PR DESCRIPTION
## Summary
- Move block drag toggle button beside HTML paste toggle
- Highlight and reset block drag state so it's disabled by default
- Add fullscreen editor toggle and supporting styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb799d28f8832cbae972fd26918922