### PR TITLE
Improve editor background and media controls

### DIFF
--- a/index.css
+++ b/index.css
@@ -112,7 +112,7 @@
         .notes-modal-content.fullscreen .resizer-e-panel { display: none; }
         .notes-modal-content.fullscreen #notes-main-content { flex: 0 0 auto; }
         .notes-modal-content.fullscreen #notes-editor {
-            background: #F8FBFD;
+            background: #fff;
             border: 1px solid var(--border-color);
         }
 

--- a/index.css
+++ b/index.css
@@ -107,12 +107,12 @@
         
         .notes-modal-content { max-width: 900px; height: 95vh; max-height: 95vh; padding: 0; }
 
-        .notes-modal-content.fullscreen { max-width: 100vw; width: 100vw; height: 95vh; background: #fff; }
+        .notes-modal-content.fullscreen { max-width: 100vw; width: 100vw; height: 95vh; background: #F8FBFD; }
         .notes-modal-content.fullscreen #notes-side-panel,
         .notes-modal-content.fullscreen .resizer-e-panel { display: none; }
         .notes-modal-content.fullscreen #notes-main-content { flex: 0 0 auto; }
         .notes-modal-content.fullscreen #notes-editor {
-            background: #fff;
+            background: #F8FBFD;
             border: 1px solid var(--border-color);
         }
 
@@ -160,14 +160,19 @@
             border-top-left-radius: 0.5rem;
             border-top-right-radius: 0.5rem;
             display: flex;
-            flex-wrap: wrap; 
+            flex-wrap: wrap;
             align-items: center;
             gap: 1px;
+        }
+        .editor-toolbar .toolbar-select {
+            max-width: 90px;
+            font-size: 0.75rem;
         }
         #notes-editor { border: 1px solid var(--border-color); padding: 12px; flex-grow: 1; overflow-y: auto; border-bottom-left-radius: 0.5rem; border-bottom-right-radius: 0.5rem; line-height: 1.6; background-color: var(--bg-secondary); }
         #notes-editor:focus { outline: none; }
         #notes-editor img { max-width: 100%; height: auto; border-radius: 0.5rem; cursor: pointer; }
         #notes-editor img.selected-for-resize { outline: 2px solid var(--btn-primary-bg); }
+        #notes-editor table.selected-for-move { outline: 2px solid var(--btn-primary-bg); }
 
         /* Display multiple images in a row */
         #notes-editor .image-row {

--- a/index.js
+++ b/index.js
@@ -1251,6 +1251,7 @@ document.addEventListener('DOMContentLoaded', function () {
     let activeStatusFilter = 'all';
     let activeNoteIcon = null;
     let selectedImageForResize = null;
+    let selectedTableForMove = null;
     let saveTimeout;
     let activeReferencesCell = null;
     let activeIconPickerButton = null;
@@ -3070,6 +3071,12 @@ document.addEventListener('DOMContentLoaded', function () {
         const resizeMinusBtn = createButton('Disminuir tamaño de imagen (-10%)', '➖', null, null, () => resizeSelectedImage(0.9));
         editorToolbar.appendChild(resizeMinusBtn);
 
+        const moveLeftBtn = createButton('Mover imagen/tabla a la izquierda', '⬅️', null, null, () => moveSelectedElement(-10));
+        editorToolbar.appendChild(moveLeftBtn);
+
+        const moveRightBtn = createButton('Mover imagen/tabla a la derecha', '➡️', null, null, () => moveSelectedElement(10));
+        editorToolbar.appendChild(moveRightBtn);
+
         // Eliminamos el botón de inserción de tablas y el separador asociado
 
         // Print/Save
@@ -3191,6 +3198,20 @@ document.addEventListener('DOMContentLoaded', function () {
         } else {
             showAlert("Por favor, selecciona una imagen primero para cambiar su tamaño.");
         }
+    }
+
+    function moveSelectedElement(deltaX) {
+        let elem = selectedImageForResize || selectedTableForMove;
+        if (elem && elem.tagName === 'IMG') {
+            const fig = elem.closest('figure.float-image');
+            if (fig) elem = fig;
+        }
+        if (!elem) {
+            showAlert("Selecciona una imagen o tabla para moverla.");
+            return;
+        }
+        const current = parseFloat(elem.style.marginLeft) || 0;
+        elem.style.marginLeft = `${current + deltaX}px`;
     }
 
     function updateAllTotals() {
@@ -5188,6 +5209,17 @@ document.addEventListener('DOMContentLoaded', function () {
              } else {
                  document.querySelectorAll('#notes-editor img').forEach(img => img.classList.remove('selected-for-resize'));
                  selectedImageForResize = null;
+             }
+
+             // Handle table selection
+             const tbl = e.target.closest('table');
+             if (tbl && notesEditor.contains(tbl)) {
+                 notesEditor.querySelectorAll('table').forEach(t => t.classList.remove('selected-for-move'));
+                 tbl.classList.add('selected-for-move');
+                 selectedTableForMove = tbl;
+             } else {
+                 notesEditor.querySelectorAll('table').forEach(t => t.classList.remove('selected-for-move'));
+                 selectedTableForMove = null;
              }
 
              // Handle gallery link clicks


### PR DESCRIPTION
## Summary
- use #F8FBFD for near-fullscreen editor background
- shrink font/zoom/size/line-height selectors to free toolbar space
- add left/right buttons to nudge selected images or tables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb8b0b7ea0832c9b931427e9fb9081