### PR TITLE
fix: ui menus and drag toggle

### DIFF
--- a/editor-enhancements.js
+++ b/editor-enhancements.js
@@ -82,31 +82,10 @@ export function setupAdvancedEditing(editor) {
     return null;
   }
 
-  let dragLine = null;
-  editor.addEventListener('dragstart', e => {
-    const line = e.target.closest('p');
-    if (!line) return;
-    dragLine = line;
-    e.dataTransfer.setData('text/plain', '');
-  });
-  editor.addEventListener('dragover', e => {
-    const line = e.target.closest('p');
-    if (!line || !dragLine || line === dragLine) return;
-    e.preventDefault();
-  });
-  editor.addEventListener('drop', e => {
-    const line = e.target.closest('p');
-    if (!line || !dragLine || line === dragLine) return;
-    e.preventDefault();
-    editor.insertBefore(dragLine, line);
-    dragLine = null;
-  });
-
-  editor.querySelectorAll('p').forEach(p => p.setAttribute('draggable', 'true'));
-  const observer = new MutationObserver(() => {
-    editor.querySelectorAll('p').forEach(p => {
-      if (!p.getAttribute('draggable')) p.setAttribute('draggable', 'true');
-    });
-  });
-  observer.observe(editor, { childList: true, subtree: true });
+  // Previously, the editor enabled dragging of paragraphs by default to allow
+  // reordering lines. This interfered with the "hand" tool in the main
+  // application because elements kept the `draggable` attribute even when block
+  // dragging was disabled. By removing the automatic draggable behavior and the
+  // related observers, the editor respects the default state where text can be
+  // selected normally unless block dragging is explicitly enabled elsewhere.
 }

--- a/index.css
+++ b/index.css
@@ -101,6 +101,10 @@
         
         .modal-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.5); display: flex; align-items: center; justify-content: center; z-index: 1000; opacity: 0; visibility: hidden; transition: opacity 0.3s ease, visibility 0.3s ease; }
         .modal-overlay.visible { opacity: 1; visibility: visible; }
+
+        /* Ensure the HTML insertion dialog appears above other overlays,
+           particularly when editing sub-notes where multiple modals stack. */
+        #html-code-modal { z-index: 1100; }
         
         .modal-content { background: var(--modal-bg); color: var(--modal-text); padding: 1.5rem; border-radius: 0.5rem; width: 95%; box-shadow: 0 5px 15px rgba(0,0,0,0.3); transform: translateY(-20px); transition: transform 0.3s ease; display: flex; flex-direction: column; }
         .modal-overlay.visible .modal-content { transform: translateY(0); }

--- a/index.js
+++ b/index.js
@@ -766,7 +766,18 @@ document.addEventListener('DOMContentLoaded', function () {
                 document.querySelectorAll('.color-submenu.visible, .symbol-dropdown-content.visible').forEach(d => {
                     if (d !== submenu) d.classList.remove('visible');
                 });
+                const willShow = !submenu.classList.contains('visible');
                 submenu.classList.toggle('visible');
+                if (willShow) {
+                    // Position submenu within viewport
+                    submenu.style.left = '0';
+                    submenu.style.right = 'auto';
+                    const rect = submenu.getBoundingClientRect();
+                    if (rect.right > window.innerWidth) {
+                        submenu.style.left = 'auto';
+                        submenu.style.right = '0';
+                    }
+                }
             });
             return group;
         };
@@ -2514,7 +2525,18 @@ document.addEventListener('DOMContentLoaded', function () {
                 document.querySelectorAll('.color-submenu.visible, .symbol-dropdown-content.visible').forEach(d => {
                     if (d !== submenu) d.classList.remove('visible');
                 });
+                const willShow = !submenu.classList.contains('visible');
                 submenu.classList.toggle('visible');
+                if (willShow) {
+                    // Position submenu within viewport
+                    submenu.style.left = '0';
+                    submenu.style.right = 'auto';
+                    const rect = submenu.getBoundingClientRect();
+                    if (rect.right > window.innerWidth) {
+                        submenu.style.left = 'auto';
+                        submenu.style.right = '0';
+                    }
+                }
             });
             
             return group;


### PR DESCRIPTION
## Summary
- prevent color palette overflow on the right edge
- ensure HTML insert modal appears above other overlays
- remove default paragraph dragging to respect hand-tool state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdfdef2a30832c8844eb109aff6a92