### PR TITLE
Fix editor overlays and block drag behavior

### DIFF
--- a/index.css
+++ b/index.css
@@ -899,7 +899,7 @@ hr.hr-dashed { border-top: 1px dashed var(--text-primary); }
 .predef-note-btn { margin:0; cursor:pointer; }
 
 /* Ensure HTML code modal appears above other dialogs */
-#html-code-modal { z-index: 1100; }
+#html-code-modal { z-index: 3000; }
 
 /* Tabs for multiple open notes */
 #note-tabs-bar {

--- a/index.js
+++ b/index.js
@@ -767,6 +767,16 @@ document.addEventListener('DOMContentLoaded', function () {
                     if (d !== submenu) d.classList.remove('visible');
                 });
                 submenu.classList.toggle('visible');
+                if (submenu.classList.contains('visible')) {
+                    // Reset positioning then measure to avoid clipping at viewport edges
+                    submenu.style.left = '0';
+                    submenu.style.right = 'auto';
+                    const rect = submenu.getBoundingClientRect();
+                    if (rect.right > window.innerWidth) {
+                        submenu.style.left = 'auto';
+                        submenu.style.right = '0';
+                    }
+                }
             });
             return group;
         };
@@ -2515,6 +2525,15 @@ document.addEventListener('DOMContentLoaded', function () {
                     if (d !== submenu) d.classList.remove('visible');
                 });
                 submenu.classList.toggle('visible');
+                if (submenu.classList.contains('visible')) {
+                    submenu.style.left = '0';
+                    submenu.style.right = 'auto';
+                    const rect = submenu.getBoundingClientRect();
+                    if (rect.right > window.innerWidth) {
+                        submenu.style.left = 'auto';
+                        submenu.style.right = '0';
+                    }
+                }
             });
             
             return group;
@@ -4055,6 +4074,10 @@ document.addEventListener('DOMContentLoaded', function () {
     function saveCurrentNote() {
         if (!currentNoteRow || !currentNotesArray || currentNotesArray.length === 0) return;
         
+        notesEditor.querySelectorAll('[draggable]').forEach(el => {
+            el.removeAttribute('draggable');
+            if (el.style.cursor === 'move') el.style.cursor = '';
+        });
         const currentContent = notesEditor.innerHTML;
         const currentTitle = notesModalTitle.textContent.trim();
         
@@ -4185,6 +4208,10 @@ document.addEventListener('DOMContentLoaded', function () {
         
         notesModalTitle.textContent = note.title || `Nota ${index + 1}`;
         notesEditor.innerHTML = note.content || '<p><br></p>';
+        notesEditor.querySelectorAll('[draggable]').forEach(el => {
+            el.removeAttribute('draggable');
+            if (el.style.cursor === 'move') el.style.cursor = '';
+        });
         notesEditor.querySelectorAll('table').forEach(initTableResize);
 
         renderNotesList();


### PR DESCRIPTION
## Summary
- Reposition color palette menus so they don't get cut off at the viewport edge
- Raise HTML insert modal z-index to appear above other dialogs
- Clean up draggable attributes on save/load to keep block drag mode disabled by default

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdfdef2a30832c8844eb109aff6a92