### PR TITLE
Fix color palette overflow, modal z-index and block drag toggle

### DIFF
--- a/index.css
+++ b/index.css
@@ -101,9 +101,11 @@
         
         .modal-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.5); display: flex; align-items: center; justify-content: center; z-index: 1000; opacity: 0; visibility: hidden; transition: opacity 0.3s ease, visibility 0.3s ease; }
         .modal-overlay.visible { opacity: 1; visibility: visible; }
-        
+
         .modal-content { background: var(--modal-bg); color: var(--modal-text); padding: 1.5rem; border-radius: 0.5rem; width: 95%; box-shadow: 0 5px 15px rgba(0,0,0,0.3); transform: translateY(-20px); transition: transform 0.3s ease; display: flex; flex-direction: column; }
         .modal-overlay.visible .modal-content { transform: translateY(0); }
+
+        #html-code-modal { z-index: 1100; }
         
         .notes-modal-content { max-width: 900px; height: 95vh; max-height: 95vh; padding: 0; }
 

--- a/index.js
+++ b/index.js
@@ -767,6 +767,15 @@ document.addEventListener('DOMContentLoaded', function () {
                     if (d !== submenu) d.classList.remove('visible');
                 });
                 submenu.classList.toggle('visible');
+                if (submenu.classList.contains('visible')) {
+                    submenu.style.left = '0';
+                    submenu.style.right = 'auto';
+                    const rect = submenu.getBoundingClientRect();
+                    if (rect.right > window.innerWidth) {
+                        submenu.style.left = 'auto';
+                        submenu.style.right = '0';
+                    }
+                }
             });
             return group;
         };
@@ -2199,9 +2208,9 @@ document.addEventListener('DOMContentLoaded', function () {
             notesEditor.removeEventListener('dragstart', onDragStart);
             notesEditor.removeEventListener('dragover', onDragOver);
             notesEditor.removeEventListener('drop', onDrop);
-            notesEditor.querySelectorAll(blockSelector).forEach(block => {
-                block.removeAttribute('draggable');
-                block.style.cursor = '';
+            notesEditor.querySelectorAll('[draggable="true"]').forEach(el => {
+                el.removeAttribute('draggable');
+                el.style.cursor = '';
             });
             draggedBlock = null;
         };
@@ -2515,8 +2524,17 @@ document.addEventListener('DOMContentLoaded', function () {
                     if (d !== submenu) d.classList.remove('visible');
                 });
                 submenu.classList.toggle('visible');
+                if (submenu.classList.contains('visible')) {
+                    submenu.style.left = '0';
+                    submenu.style.right = 'auto';
+                    const rect = submenu.getBoundingClientRect();
+                    if (rect.right > window.innerWidth) {
+                        submenu.style.left = 'auto';
+                        submenu.style.right = '0';
+                    }
+                }
             });
-            
+
             return group;
         };
 


### PR DESCRIPTION
## Summary
- Keep color menus within viewport in main and sub-note editors
- Ensure HTML insert dialog overlays sub-note editor
- Reset block dragging to prevent accidental block selection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdfdef2a30832c8844eb109aff6a92