### PR TITLE
Fix UI issues in note editor

### DIFF
--- a/index.css
+++ b/index.css
@@ -108,9 +108,9 @@
         .notes-modal-content { max-width: 900px; height: 95vh; max-height: 95vh; padding: 0; }
 
         .notes-modal-content.fullscreen { max-width: 100vw; width: 100vw; height: 95vh; background: #F8FBFD; }
-        .notes-modal-content.fullscreen #notes-side-panel,
+        .notes-modal-content.fullscreen #notes-side-panel:not(.open),
         .notes-modal-content.fullscreen .resizer-e-panel { display: none; }
-        .notes-modal-content.fullscreen #notes-main-content { flex: 0 0 auto; }
+        .notes-modal-content.fullscreen #notes-main-content { flex-grow: 1; }
         .notes-modal-content.fullscreen #notes-editor {
             background: #fff;
             border: 1px solid var(--border-color);
@@ -899,7 +899,7 @@ hr.hr-dashed { border-top: 1px dashed var(--text-primary); }
 .predef-note-btn { margin:0; cursor:pointer; }
 
 /* Ensure HTML code modal appears above other dialogs */
-#html-code-modal { z-index: 1100; }
+#html-code-modal { z-index: 2100; }
 
 /* Tabs for multiple open notes */
 #note-tabs-bar {

--- a/index.js
+++ b/index.js
@@ -767,6 +767,16 @@ document.addEventListener('DOMContentLoaded', function () {
                     if (d !== submenu) d.classList.remove('visible');
                 });
                 submenu.classList.toggle('visible');
+                if (submenu.classList.contains('visible')) {
+                    submenu.style.left = '0';
+                    submenu.style.right = 'auto';
+                    const menuRect = submenu.getBoundingClientRect();
+                    const containerRect = group.parentElement.getBoundingClientRect();
+                    if (menuRect.right > containerRect.right) {
+                        submenu.style.left = 'auto';
+                        submenu.style.right = '0';
+                    }
+                }
             });
             return group;
         };
@@ -2515,6 +2525,16 @@ document.addEventListener('DOMContentLoaded', function () {
                     if (d !== submenu) d.classList.remove('visible');
                 });
                 submenu.classList.toggle('visible');
+                if (submenu.classList.contains('visible')) {
+                    submenu.style.left = '0';
+                    submenu.style.right = 'auto';
+                    const menuRect = submenu.getBoundingClientRect();
+                    const containerRect = group.parentElement.getBoundingClientRect();
+                    if (menuRect.right > containerRect.right) {
+                        submenu.style.left = 'auto';
+                        submenu.style.right = '0';
+                    }
+                }
             });
             
             return group;
@@ -4052,16 +4072,17 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     }
 
-    function saveCurrentNote() {
+    function saveCurrentNote(index = activeNoteIndex) {
         if (!currentNoteRow || !currentNotesArray || currentNotesArray.length === 0) return;
-        
+        if (index < 0 || index >= currentNotesArray.length) return;
+
         const currentContent = notesEditor.innerHTML;
         const currentTitle = notesModalTitle.textContent.trim();
-        
+
         // Keep existing postits and quick note data
-        const existingPostits = currentNotesArray[activeNoteIndex].postits || {};
-        const existingQuickNote = currentNotesArray[activeNoteIndex].quickNote || '';
-        currentNotesArray[activeNoteIndex] = {
+        const existingPostits = currentNotesArray[index].postits || {};
+        const existingQuickNote = currentNotesArray[index].quickNote || '';
+        currentNotesArray[index] = {
             title: currentTitle,
             content: currentContent,
             lastEdited: new Date().toISOString(),
@@ -4169,6 +4190,9 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     function loadNoteIntoEditor(index) {
+        if (index !== activeNoteIndex && currentNotesArray.length > 0) {
+            saveCurrentNote(activeNoteIndex);
+        }
         if (index < 0 || index >= currentNotesArray.length) {
             if (currentNotesArray.length === 0) {
                addNewNote(false);
@@ -4176,7 +4200,7 @@ document.addEventListener('DOMContentLoaded', function () {
             }
             index = 0; // fallback to the first note
         }
-        
+
         activeNoteIndex = index;
         const note = currentNotesArray[index];
 


### PR DESCRIPTION
## Summary
- Reposition color picker menus to avoid clipping at window edge
- Raise insert-HTML dialog z-index so it appears above active screens
- Allow side panel to toggle in fullscreen and save notes before switching to prevent overwrite

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be17660a68832ca23db3f5ea248ecc