### PR TITLE
feat: add multi-format save options

### DIFF
--- a/index.html
+++ b/index.html
@@ -639,6 +639,10 @@
     <button id="restore-note-btn" class="hidden fixed bottom-4 left-4 p-3 bg-blue-600 text-white rounded-full shadow-lg" aria-label="Restaurar nota">📝</button>
 
     <div id="print-area" class="hidden"></div>
-<script src="index.js" type="module"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.9.3/html2pdf.bundle.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html-docx-js/0.10.3/html-docx.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/turndown/7.1.2/turndown.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+    <script src="index.js" type="module"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add save dropdown with HTML, PDF, DOCX, ODT, EPUB and Markdown options
- support content export logic for each format
- include required client-side libraries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be2b1b08d0832ca7944558bfc9ff2b