### PR TITLE
Add preset text style dropdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -2743,6 +2743,63 @@ document.addEventListener('DOMContentLoaded', function () {
             notesEditor.focus();
         };
 
+        const applyPresetStyle = (cssText) => {
+            const sel = window.getSelection();
+            if (!sel || sel.rangeCount === 0) return;
+            const range = sel.getRangeAt(0);
+            if (range.collapsed) return;
+            const span = document.createElement('span');
+            span.style.cssText = cssText;
+            span.appendChild(range.extractContents());
+            range.insertNode(span);
+            collapseSelection(notesEditor);
+        };
+
+        const createPresetStyleDropdown = () => {
+            const dropdown = document.createElement('div');
+            dropdown.className = 'symbol-dropdown';
+            const btn = createButton('Estilos de texto', '🖌️', null, null, null);
+            dropdown.appendChild(btn);
+            const content = document.createElement('div');
+            content.className = 'symbol-dropdown-content flex-dropdown';
+            const styles = [
+                { label: 'Texto estilo celeste', style: 'font-family:Arial; font-weight:600; background:#e0f7fa; color:#01579b; padding:2px 4px; border-radius:4px;' },
+                { label: 'Texto estilo lila', style: 'font-family:Arial; font-weight:600; background:#f3e5f5; color:#6a1b9a; padding:2px 4px; border-radius:4px;' },
+                { label: 'Texto estilo menta', style: 'font-family:Arial; font-weight:600; background:#e8f5e9; color:#1b5e20; padding:2px 4px; border-radius:4px;' },
+                { label: 'Texto estilo durazno', style: 'font-family:Arial; font-weight:600; background:#fff3e0; color:#e65100; padding:2px 4px; border-radius:4px;' },
+                { label: 'Texto estilo amarillo', style: 'font-family:Arial; font-weight:600; background:#fffde7; color:#f57f17; padding:2px 4px; border-radius:4px;' },
+                { label: 'Texto estilo rosado', style: 'font-family:Arial; font-weight:600; background:#fce4ec; color:#ad1457; padding:2px 4px; border-radius:4px;' },
+                { label: 'Texto estilo azul', style: 'font-family:Arial; font-weight:600; background:#e3f2fd; color:#1a237e; padding:2px 4px; border-radius:4px;' },
+                { label: 'Texto estilo turquesa', style: 'font-family:Arial; font-weight:600; background:#e0f2f1; color:#004d40; padding:2px 4px; border-radius:4px;' },
+                { label: 'Texto estilo arena', style: 'font-family:Arial; font-weight:600; background:#fbe9e7; color:#4e342e; padding:2px 4px; border-radius:4px;' },
+                { label: 'Texto estilo café', style: 'font-family:Arial; font-weight:600; background:#efebe9; color:#5d4037; padding:2px 4px; border-radius:4px;' },
+                { label: 'Texto estilo rojo', style: 'font-family:Arial; font-weight:600; background:#f44336; color:#ffffff; padding:2px 4px; border-radius:4px;' },
+                { label: 'Texto estilo verde oscuro', style: 'font-family:Arial; font-weight:600; background:#1b5e20; color:#ffffff; padding:2px 4px; border-radius:4px;' }
+            ];
+            styles.forEach(s => {
+                const opt = document.createElement('button');
+                opt.className = 'toolbar-btn';
+                opt.innerHTML = `<span style="${s.style}">${s.label}</span>`;
+                opt.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    applyPresetStyle(s.style);
+                    content.classList.remove('visible');
+                    notesEditor.focus();
+                });
+                content.appendChild(opt);
+            });
+            dropdown.appendChild(content);
+            btn.addEventListener('click', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                document.querySelectorAll('.color-submenu.visible, .symbol-dropdown-content.visible').forEach(d => {
+                    if (d !== content) d.classList.remove('visible');
+                });
+                content.classList.toggle('visible');
+            });
+            return dropdown;
+        };
+
         editorToolbar.appendChild(createButton('Reducir interlineado', '-', null, null, () => adjustLineHeight(-0.2)));
         editorToolbar.appendChild(createButton('Aumentar interlineado', '+', null, null, () => adjustLineHeight(0.2)));
 
@@ -2755,6 +2812,7 @@ document.addEventListener('DOMContentLoaded', function () {
         editorToolbar.appendChild(createButton('Subrayado', '<u>U</u>', 'underline'));
         editorToolbar.appendChild(createButton('Tachado', '<s>S</s>', 'strikeThrough'));
         editorToolbar.appendChild(createButton('Superíndice', 'X²', 'superscript'));
+        editorToolbar.appendChild(createPresetStyleDropdown());
         editorToolbar.appendChild(createButton('Deshacer', '↺', null, null, undoAction));
         editorToolbar.appendChild(createButton('Rehacer', '↻', null, null, redoAction));
 


### PR DESCRIPTION
## Summary
- Add `applyPresetStyle` utility and dropdown builder for predefined highlight styles
- Wire preset style dropdown into editor toolbar for easy text formatting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be51a9cfec832c938eac458be473c8