### PR TITLE
feat: display last edited date in day-month-year format

### DIFF
--- a/index.js
+++ b/index.js
@@ -4353,7 +4353,15 @@ document.addEventListener('DOMContentLoaded', function () {
         
         infoWordCount.textContent = words.length;
         infoNoteSize.textContent = formatBytes(new Blob([note.content]).size);
-        infoLastEdited.textContent = note.lastEdited ? new Date(note.lastEdited).toLocaleString() : 'N/A';
+        infoLastEdited.textContent = note.lastEdited
+            ? new Date(note.lastEdited).toLocaleString('es-ES', {
+                day: '2-digit',
+                month: '2-digit',
+                year: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit'
+            })
+            : 'N/A';
     }
 
     function renderNoteTabs() {


### PR DESCRIPTION
## Summary
- format last edited date using Spanish locale to show day-month-year and time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1d2546b74832c857b1391d2c09437