### PR TITLE
Fix preset text styles and add table editing menu

### DIFF
--- a/index.css
+++ b/index.css
@@ -885,9 +885,6 @@ table.resizable-table.selected .table-resize-handle {
 .indent-4 { margin-left: 4rem; }
 .indent-5 { margin-left: 5rem; }
 
-hr.hr-solid { border-top: 1px solid var(--text-primary); }
-hr.hr-dotted { border-top: 1px dotted var(--text-primary); }
-hr.hr-dashed { border-top: 1px dashed var(--text-primary); }
 .preset-style-popup,
 .table-menu-popup {
     position: absolute;
@@ -908,16 +905,28 @@ hr.hr-dashed { border-top: 1px dashed var(--text-primary); }
 }
 .table-theme-blue { border-collapse: collapse; }
 .table-theme-blue th, .table-theme-blue td { border:1px solid #2196f3; }
-.table-theme-blue th { background:#bbdefb; }
-.table-theme-blue td { background:#e3f2fd; }
+.table-theme-blue th { background:#bbdefb; color:#0d47a1; }
+.table-theme-blue td { background:#ffffff; }
 .table-theme-green { border-collapse: collapse; }
 .table-theme-green th, .table-theme-green td { border:1px solid #4caf50; }
-.table-theme-green th { background:#c8e6c9; }
-.table-theme-green td { background:#e8f5e9; }
+.table-theme-green th { background:#c8e6c9; color:#1b5e20; }
+.table-theme-green td { background:#ffffff; }
 .table-theme-gray { border-collapse: collapse; }
 .table-theme-gray th, .table-theme-gray td { border:1px solid #9e9e9e; }
-.table-theme-gray th { background:#e0e0e0; }
-.table-theme-gray td { background:#f5f5f5; }
+.table-theme-gray th { background:#e0e0e0; color:#212121; }
+.table-theme-gray td { background:#ffffff; }
+.table-theme-red { border-collapse: collapse; }
+.table-theme-red th, .table-theme-red td { border:1px solid #f44336; }
+.table-theme-red th { background:#ffcdd2; color:#b71c1c; }
+.table-theme-red td { background:#ffffff; }
+.table-theme-purple { border-collapse: collapse; }
+.table-theme-purple th, .table-theme-purple td { border:1px solid #9c27b0; }
+.table-theme-purple th { background:#e1bee7; color:#4a148c; }
+.table-theme-purple td { background:#ffffff; }
+.table-theme-teal { border-collapse: collapse; }
+.table-theme-teal th, .table-theme-teal td { border:1px solid #009688; }
+.table-theme-teal th { background:#e0f2f1; color:#004d40; }
+.table-theme-teal td { background:#ffffff; }
 .note-resizable {
     resize: horizontal;
     overflow: auto;


### PR DESCRIPTION
## Summary
- Fix preset text style application and show floating style menu on styled text
- Add floating table menu with row/column controls and theme presets
- Improve indent handling, reset style on new line, and add colorful pill separators

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c371eae368832c9d4d07bcb88b3bcc