### PR TITLE
feat: enhance editor styling and table tools

### DIFF
--- a/index.css
+++ b/index.css
@@ -1114,3 +1114,30 @@ hr.hr-dashed { border-top: 1px dashed var(--text-primary); }
   margin-top: 4px;
   display: block;
 }
+
+.style-float-menu,
+.table-float-menu {
+  position: absolute;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  padding: 4px;
+  border-radius: 4px;
+  z-index: 10002;
+  display: flex;
+  gap: 4px;
+}
+
+.table-theme {
+  border-collapse: collapse;
+}
+.table-theme td,
+.table-theme th {
+  border: 1px solid var(--tbl-border);
+  padding: 4px;
+}
+.table-theme th {
+  background: var(--tbl-header);
+}
+.table-theme-blue { --tbl-border: #93c5fd; --tbl-header: #bfdbfe; }
+.table-theme-green { --tbl-border: #86efac; --tbl-header: #bbf7d0; }
+.table-theme-purple { --tbl-border: #d8b4fe; --tbl-header: #e9d5ff; }


### PR DESCRIPTION
## Summary
- fix preset text styling at line start and allow changing style via floating menu
- add floating table menu with row/column tools and theme options
- introduce gradient separators and table theme styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c371eae368832c9d4d07bcb88b3bcc