### PR TITLE
feat: enhance text editor styling and tables

### DIFF
--- a/index.css
+++ b/index.css
@@ -1114,3 +1114,75 @@ hr.hr-dashed { border-top: 1px dashed var(--text-primary); }
   margin-top: 4px;
   display: block;
 }
+
+#style-tooltip {
+  position: absolute;
+  background: var(--bg-secondary, #fff);
+  border: 1px solid var(--border-color);
+  padding: 4px;
+  border-radius: 4px;
+  z-index: 2000;
+  display: none;
+}
+#style-tooltip button {
+  display: block;
+  margin: 2px 0;
+}
+
+#table-menu {
+  position: absolute;
+  background: var(--bg-secondary, #fff);
+  border: 1px solid var(--border-color);
+  padding: 4px;
+  border-radius: 4px;
+  z-index: 2000;
+  display: none;
+}
+#table-menu button {
+  display: block;
+  margin: 2px 0;
+}
+
+.table-theme-blue {
+  border: 1px solid #3b82f6;
+}
+.table-theme-blue th {
+  background: #dbeafe;
+}
+.table-theme-blue td {
+  border: 1px solid #3b82f6;
+}
+.table-theme-green {
+  border: 1px solid #10b981;
+}
+.table-theme-green th {
+  background: #d1fae5;
+}
+.table-theme-green td {
+  border: 1px solid #10b981;
+}
+
+hr.hr-gradient-thick-yellow {height:12px;margin:20px 0;border-radius:6px;border:none;background:linear-gradient(to right,#fffde7,#fff176);}
+hr.hr-gradient-thick-orange {height:12px;margin:20px 0;border-radius:6px;border:none;background:linear-gradient(to right,#ffe0b2,#ff9800);}
+hr.hr-gradient-thick-blue {height:12px;margin:20px 0;border-radius:6px;border:none;background:linear-gradient(to right,#bbdefb,#2196f3);}
+hr.hr-gradient-thick-lightblue {height:12px;margin:20px 0;border-radius:6px;border:none;background:linear-gradient(to right,#e1f5fe,#4fc3f7);}
+hr.hr-gradient-thick-darkgreen {height:12px;margin:20px 0;border-radius:6px;border:none;background:linear-gradient(to right,#c8e6c9,#388e3c);}
+hr.hr-gradient-thick-lightgreen {height:12px;margin:20px 0;border-radius:6px;border:none;background:linear-gradient(to right,#dcedc8,#8bc34a);}
+hr.hr-gradient-thick-purple {height:12px;margin:20px 0;border-radius:6px;border:none;background:linear-gradient(to right,#e1bee7,#9c27b0);}
+hr.hr-gradient-thick-brown {height:12px;margin:20px 0;border-radius:6px;border:none;background:linear-gradient(to right,#d7ccc8,#795548);}
+hr.hr-gradient-thick-gray {height:12px;margin:20px 0;border-radius:6px;border:none;background:linear-gradient(to right,#f5f5f5,#9e9e9e);}
+hr.hr-gradient-thick-red {height:12px;margin:20px 0;border-radius:6px;border:none;background:linear-gradient(to right,#ffcdd2,#f44336);}
+hr.hr-gradient-thin-yellow {height:4px;margin:12px 0;border-radius:2px;border:none;background:linear-gradient(to right,#fffde7,#fff176);}
+hr.hr-gradient-thin-orange {height:4px;margin:12px 0;border-radius:2px;border:none;background:linear-gradient(to right,#ffe0b2,#ff9800);}
+hr.hr-gradient-thin-blue {height:4px;margin:12px 0;border-radius:2px;border:none;background:linear-gradient(to right,#bbdefb,#2196f3);}
+hr.hr-gradient-thin-lightblue {height:4px;margin:12px 0;border-radius:2px;border:none;background:linear-gradient(to right,#e1f5fe,#4fc3f7);}
+hr.hr-gradient-thin-darkgreen {height:4px;margin:12px 0;border-radius:2px;border:none;background:linear-gradient(to right,#c8e6c9,#388e3c);}
+hr.hr-gradient-thin-lightgreen {height:4px;margin:12px 0;border-radius:2px;border:none;background:linear-gradient(to right,#dcedc8,#8bc34a);}
+hr.hr-gradient-thin-purple {height:4px;margin:12px 0;border-radius:2px;border:none;background:linear-gradient(to right,#e1bee7,#9c27b0);}
+hr.hr-gradient-thin-brown {height:4px;margin:12px 0;border-radius:2px;border:none;background:linear-gradient(to right,#d7ccc8,#795548);}
+hr.hr-gradient-thin-gray {height:4px;margin:12px 0;border-radius:2px;border:none;background:linear-gradient(to right,#f5f5f5,#9e9e9e);}
+hr.hr-gradient-thin-red {height:4px;margin:12px 0;border-radius:2px;border:none;background:linear-gradient(to right,#ffcdd2,#f44336);}
+
+span.preset-style {
+  display: inline-block;
+}


### PR DESCRIPTION
## Summary
- add tooltip to change preset text styles and context menu for tables
- reset formatting on new lines and broaden indent handling for multi-line selections
- include advanced pill and gradient separators with corresponding styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c371eae368832c9d4d07bcb88b3bcc