### PR TITLE
Mejoras en menú de tablas y divisores

### DIFF
--- a/index.css
+++ b/index.css
@@ -903,6 +903,25 @@ table.resizable-table.selected .table-resize-handle {
     text-align: left;
     margin: 2px 0;
 }
+
+.table-menu-tabs {
+    display: flex;
+    gap: 4px;
+    margin-bottom: 4px;
+}
+.table-menu-tab {
+    flex: 1;
+    padding: 2px;
+    cursor: pointer;
+    border: 1px solid var(--border-color, #ccc);
+    background: var(--bg-secondary, #fff);
+}
+.table-menu-tab.active {
+    background: var(--btn-primary-bg, #2563eb);
+    color: var(--btn-primary-text, #fff);
+}
+.table-menu-section { display: none; }
+.table-menu-section.active { display: block; }
 .table-theme-blue { border-collapse: collapse; }
 .table-theme-blue th, .table-theme-blue td { border:1px solid #2196f3; }
 .table-theme-blue th { background:#bbdefb; color:#0d47a1; }


### PR DESCRIPTION
## Resumen
- Restablece la herramienta de texto píldora evitando que se pierda la selección.
- Rediseña el menú flotante de tablas con pestañas e incorpora modo de redimensionamiento.
- Añade líneas divisoras simples, segmentadas, punteadas y con gradientes.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3825c7e18832cb8c8dd3e889a0596