### PR TITLE
Enhance editor menus and divider lines

### DIFF
--- a/index.css
+++ b/index.css
@@ -903,6 +903,18 @@ table.resizable-table.selected .table-resize-handle {
     text-align: left;
     margin: 2px 0;
 }
+.table-menu-tabs {
+    display: flex;
+    border-bottom: 1px solid var(--border-color, #ccc);
+    margin-bottom: 4px;
+}
+.table-menu-tabs button {
+    flex: 1;
+    background: none;
+    border: none;
+    padding: 4px;
+    cursor: pointer;
+}
 .table-theme-blue { border-collapse: collapse; }
 .table-theme-blue th, .table-theme-blue td { border:1px solid #2196f3; }
 .table-theme-blue th { background:#bbdefb; color:#0d47a1; }


### PR DESCRIPTION
## Summary
- Preserve selection when using pill text tool so color popup appears correctly
- Redesign table tools menu with tabs, icons, and resize toggle
- Expand divider line options with solid, dashed, dotted, and gradient styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3825c7e18832cb8c8dd3e889a0596