### PR TITLE
Add customizable callout note styles

### DIFF
--- a/index.css
+++ b/index.css
@@ -864,8 +864,9 @@ table.resizable-table.selected .table-resize-handle {
 
 /* Note callout styles */
 .note-callout {
+    border: none;
+    border-left: 4px solid var(--border-color, #000);
     border-radius: 8px;
-    border: 2px solid var(--border-color);
     padding: 8px;
     margin: 8px 0;
 }
@@ -957,12 +958,12 @@ table.resizable-table.selected .table-resize-handle {
     display: inline-block;
     max-width: 100%;
 }
-.note-blue { background-color: #dbeafe; border-color: #3b82f6; }
-.note-green { background-color: #d1fae5; border-color: #10b981; }
-.note-yellow { background-color: #fef9c3; border-color: #eab308; }
-.note-red { background-color: #fee2e2; border-color: #ef4444; }
-.note-purple { background-color: #ede9fe; border-color: #8b5cf6; }
-.note-gray { background-color: #f3f4f6; border-color: #6b7280; }
+.note-blue { background-color: #dbeafe; --border-color: #3b82f6; }
+.note-green { background-color: #d1fae5; --border-color: #10b981; }
+.note-yellow { background-color: #fef9c3; --border-color: #eab308; }
+.note-red { background-color: #fee2e2; --border-color: #ef4444; }
+.note-purple { background-color: #ede9fe; --border-color: #8b5cf6; }
+.note-gray { background-color: #f3f4f6; --border-color: #6b7280; }
 .note-shadow { box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
 .predef-note-btn { margin:0; cursor:pointer; }
 

--- a/index.html
+++ b/index.html
@@ -620,7 +620,7 @@
                 <label class="flex items-center justify-between">Fondo <input type="color" id="note-bg-color" value="#ffffff" class="border"></label>
                 <label class="flex items-center justify-between">Borde <input type="color" id="note-border-color" value="#000000" class="border"></label>
                 <label class="flex items-center justify-between">Radio <input type="number" id="note-radius" value="8" class="w-16 border"></label>
-                <label class="flex items-center justify-between">Espesor <input type="number" id="note-border-width" value="2" class="w-16 border"></label>
+                <label class="flex items-center justify-between">Espesor <input type="number" id="note-border-width" value="4" class="w-16 border"></label>
                 <label class="flex items-center justify-between">Padding <input type="number" id="note-padding" value="8" class="w-16 border"></label>
                 <label class="flex items-center justify-between">Margen vertical <input type="number" id="note-margin" value="8" class="w-16 border"></label>
                 <label class="flex items-center justify-between"><span>Sombra</span><input type="checkbox" id="note-shadow"></label>

--- a/index.js
+++ b/index.js
@@ -3699,9 +3699,9 @@ document.addEventListener('DOMContentLoaded', function () {
         noteStyleCustom.classList.add('hidden');
         if (callout) {
             noteBgColorInput.value = rgbToHex(callout.style.backgroundColor || '#ffffff');
-            noteBorderColorInput.value = rgbToHex(callout.style.borderColor || '#000000');
+            noteBorderColorInput.value = rgbToHex(callout.style.borderLeftColor || '#000000');
             noteRadiusInput.value = parseInt(callout.style.borderRadius) || 8;
-            noteBorderWidthInput.value = parseInt(callout.style.borderWidth) || 2;
+            noteBorderWidthInput.value = parseInt(callout.style.borderLeftWidth) || 4;
             notePaddingInput.value = parseInt(callout.style.padding) || 8;
             noteMarginInput.value = parseInt(callout.style.marginTop) || 8;
             noteShadowInput.checked = callout.classList.contains('note-shadow');
@@ -3753,8 +3753,11 @@ document.addEventListener('DOMContentLoaded', function () {
         currentCallout.classList.remove(...PREDEF_CLASSES);
         if (opts.presetClass) currentCallout.classList.add(opts.presetClass);
         currentCallout.style.backgroundColor = opts.backgroundColor;
-        currentCallout.style.borderColor = opts.borderColor;
-        currentCallout.style.borderWidth = opts.borderWidth + 'px';
+        currentCallout.style.setProperty('--border-color', opts.borderColor);
+        currentCallout.style.border = 'none';
+        currentCallout.style.borderLeftWidth = opts.borderWidth + 'px';
+        currentCallout.style.borderLeftStyle = 'solid';
+        currentCallout.style.borderLeftColor = opts.borderColor;
         currentCallout.style.borderRadius = opts.borderRadius + 'px';
         currentCallout.style.padding = opts.padding + 'px';
         currentCallout.style.margin = opts.margin + 'px 0';
@@ -6004,7 +6007,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     backgroundColor: btn.dataset.bg,
                     borderColor: btn.dataset.border,
                     borderRadius: 8,
-                    borderWidth: 2,
+                    borderWidth: 4,
                     padding: 8,
                     margin: 8,
                     shadow: false,


### PR DESCRIPTION
## Summary
- Switch callout boxes to left-border style and support CSS variable colors
- Allow note style modal to edit existing callouts with custom left border settings
- Default preset callouts use thicker 4px border and expose border width in modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c620667948832c887db8e7fd58e665