### PR TITLE
Add customizable note callout styling

### DIFF
--- a/index.css
+++ b/index.css
@@ -864,8 +864,8 @@ table.resizable-table.selected .table-resize-handle {
 
 /* Note callout styles */
 .note-callout {
+    border-left: 4px solid #000;
     border-radius: 8px;
-    border: 2px solid var(--border-color);
     padding: 8px;
     margin: 8px 0;
 }

--- a/index.html
+++ b/index.html
@@ -620,7 +620,7 @@
                 <label class="flex items-center justify-between">Fondo <input type="color" id="note-bg-color" value="#ffffff" class="border"></label>
                 <label class="flex items-center justify-between">Borde <input type="color" id="note-border-color" value="#000000" class="border"></label>
                 <label class="flex items-center justify-between">Radio <input type="number" id="note-radius" value="8" class="w-16 border"></label>
-                <label class="flex items-center justify-between">Espesor <input type="number" id="note-border-width" value="2" class="w-16 border"></label>
+                <label class="flex items-center justify-between">Espesor <input type="number" id="note-border-width" value="4" class="w-16 border"></label>
                 <label class="flex items-center justify-between">Padding <input type="number" id="note-padding" value="8" class="w-16 border"></label>
                 <label class="flex items-center justify-between">Margen vertical <input type="number" id="note-margin" value="8" class="w-16 border"></label>
                 <label class="flex items-center justify-between"><span>Sombra</span><input type="checkbox" id="note-shadow"></label>

--- a/index.js
+++ b/index.js
@@ -3699,9 +3699,9 @@ document.addEventListener('DOMContentLoaded', function () {
         noteStyleCustom.classList.add('hidden');
         if (callout) {
             noteBgColorInput.value = rgbToHex(callout.style.backgroundColor || '#ffffff');
-            noteBorderColorInput.value = rgbToHex(callout.style.borderColor || '#000000');
+            noteBorderColorInput.value = rgbToHex(callout.style.borderLeftColor || '#000000');
             noteRadiusInput.value = parseInt(callout.style.borderRadius) || 8;
-            noteBorderWidthInput.value = parseInt(callout.style.borderWidth) || 2;
+            noteBorderWidthInput.value = parseInt(callout.style.borderLeftWidth) || 2;
             notePaddingInput.value = parseInt(callout.style.padding) || 8;
             noteMarginInput.value = parseInt(callout.style.marginTop) || 8;
             noteShadowInput.checked = callout.classList.contains('note-shadow');
@@ -3753,8 +3753,12 @@ document.addEventListener('DOMContentLoaded', function () {
         currentCallout.classList.remove(...PREDEF_CLASSES);
         if (opts.presetClass) currentCallout.classList.add(opts.presetClass);
         currentCallout.style.backgroundColor = opts.backgroundColor;
-        currentCallout.style.borderColor = opts.borderColor;
-        currentCallout.style.borderWidth = opts.borderWidth + 'px';
+        currentCallout.style.borderTop = 'none';
+        currentCallout.style.borderRight = 'none';
+        currentCallout.style.borderBottom = 'none';
+        currentCallout.style.borderLeftColor = opts.borderColor;
+        currentCallout.style.borderLeftWidth = opts.borderWidth + 'px';
+        currentCallout.style.borderLeftStyle = 'solid';
         currentCallout.style.borderRadius = opts.borderRadius + 'px';
         currentCallout.style.padding = opts.padding + 'px';
         currentCallout.style.margin = opts.margin + 'px 0';
@@ -6004,10 +6008,10 @@ document.addEventListener('DOMContentLoaded', function () {
                     backgroundColor: btn.dataset.bg,
                     borderColor: btn.dataset.border,
                     borderRadius: 8,
-                    borderWidth: 2,
+                    borderWidth: 4,
                     padding: 8,
                     margin: 8,
-                    shadow: false,
+                    shadow: btn.classList.contains('note-gray'),
                     presetClass: btn.classList.contains('note-blue') ? 'note-blue' :
                                  btn.classList.contains('note-green') ? 'note-green' :
                                  btn.classList.contains('note-yellow') ? 'note-yellow' :


### PR DESCRIPTION
## Summary
- support note callouts with configurable left border and colors
- allow changing note styles by clicking and via preset or custom options
- default note border width increased to 4px

## Testing
- `node --check index.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c620667948832c887db8e7fd58e665