### PR TITLE
feat: add configurable note styles

### DIFF
--- a/index.css
+++ b/index.css
@@ -864,8 +864,8 @@ table.resizable-table.selected .table-resize-handle {
 
 /* Note callout styles */
 .note-callout {
-    border-radius: 8px;
-    border: 2px solid var(--border-color);
+    border-left: 4px solid var(--border-color);
+    border-radius: 4px;
     padding: 8px;
     margin: 8px 0;
 }
@@ -959,9 +959,6 @@ table.resizable-table.selected .table-resize-handle {
 }
 .note-blue { background-color: #dbeafe; border-color: #3b82f6; }
 .note-green { background-color: #d1fae5; border-color: #10b981; }
-.note-yellow { background-color: #fef9c3; border-color: #eab308; }
-.note-red { background-color: #fee2e2; border-color: #ef4444; }
-.note-purple { background-color: #ede9fe; border-color: #8b5cf6; }
 .note-gray { background-color: #f3f4f6; border-color: #6b7280; }
 .note-shadow { box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
 .predef-note-btn { margin:0; cursor:pointer; }

--- a/index.html
+++ b/index.html
@@ -607,14 +607,7 @@
                 <button id="note-style-tab-custom" class="flex-1 p-1">Personalizado</button>
             </div>
             <div id="note-style-pre" class="space-y-2">
-                <div class="grid grid-cols-2 gap-2">
-                    <button class="predef-note-btn note-callout note-blue" data-bg="#dbeafe" data-border="#3b82f6">Azul</button>
-                    <button class="predef-note-btn note-callout note-green" data-bg="#d1fae5" data-border="#10b981">Verde</button>
-                    <button class="predef-note-btn note-callout note-yellow" data-bg="#fef9c3" data-border="#eab308">Amarillo</button>
-                    <button class="predef-note-btn note-callout note-red" data-bg="#fee2e2" data-border="#ef4444">Rojo</button>
-                    <button class="predef-note-btn note-callout note-purple" data-bg="#ede9fe" data-border="#8b5cf6">Morado</button>
-                    <button class="predef-note-btn note-callout note-gray" data-bg="#f3f4f6" data-border="#6b7280">Gris</button>
-                </div>
+                <div id="note-predefined-list" class="grid grid-cols-2 gap-2"></div>
             </div>
             <div id="note-style-custom" class="hidden space-y-2">
                 <label class="flex items-center justify-between">Fondo <input type="color" id="note-bg-color" value="#ffffff" class="border"></label>

--- a/index.js
+++ b/index.js
@@ -625,6 +625,37 @@ document.addEventListener('DOMContentLoaded', function () {
     const noteShadowInput = getElem('note-shadow');
     const applyNoteStyleBtn = getElem('apply-note-style-btn');
     const cancelNoteStyleBtn = getElem('cancel-note-style-btn');
+    const notePredefinedList = getElem('note-predefined-list');
+
+    const NOTE_PRESETS = [
+        { name: 'Advertencia positiva', class: 'note-green', bg: '#d1fae5', border: '#10b981' },
+        { name: 'Información', class: 'note-blue', bg: '#dbeafe', border: '#3b82f6' },
+        { name: 'Resumen', class: 'note-gray', bg: '#f3f4f6', border: '#6b7280' }
+    ];
+
+    function renderNotePresets() {
+        if (!notePredefinedList) return;
+        notePredefinedList.innerHTML = '';
+        NOTE_PRESETS.forEach(preset => {
+            const btn = document.createElement('button');
+            btn.className = `predef-note-btn note-callout ${preset.class}`;
+            btn.textContent = preset.name;
+            btn.addEventListener('click', (e) => {
+                e.preventDefault();
+                applyNoteStyle({
+                    presetClass: preset.class,
+                    backgroundColor: preset.bg,
+                    borderColor: preset.border,
+                    borderWidth: 4,
+                    borderRadius: 4,
+                    padding: 8,
+                    margin: 8,
+                    shadow: false
+                });
+            });
+            notePredefinedList.appendChild(btn);
+        });
+    }
 
     /*
      * Build the simplified toolbar for sub-note editing.  This toolbar intentionally omits
@@ -3699,9 +3730,9 @@ document.addEventListener('DOMContentLoaded', function () {
         noteStyleCustom.classList.add('hidden');
         if (callout) {
             noteBgColorInput.value = rgbToHex(callout.style.backgroundColor || '#ffffff');
-            noteBorderColorInput.value = rgbToHex(callout.style.borderColor || '#000000');
-            noteRadiusInput.value = parseInt(callout.style.borderRadius) || 8;
-            noteBorderWidthInput.value = parseInt(callout.style.borderWidth) || 2;
+            noteBorderColorInput.value = rgbToHex(callout.style.borderLeftColor || '#000000');
+            noteRadiusInput.value = parseInt(callout.style.borderRadius) || 4;
+            noteBorderWidthInput.value = parseInt(callout.style.borderLeftWidth) || 4;
             notePaddingInput.value = parseInt(callout.style.padding) || 8;
             noteMarginInput.value = parseInt(callout.style.marginTop) || 8;
             noteShadowInput.checked = callout.classList.contains('note-shadow');
@@ -3714,7 +3745,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     function applyNoteStyle(opts) {
-        const PREDEF_CLASSES = ['note-blue','note-green','note-yellow','note-red','note-purple','note-gray'];
+        const PREDEF_CLASSES = ['note-blue','note-green','note-gray'];
         if (!currentCallout) {
             const callout = document.createElement('div');
             callout.className = 'note-callout';
@@ -3753,11 +3784,12 @@ document.addEventListener('DOMContentLoaded', function () {
         currentCallout.classList.remove(...PREDEF_CLASSES);
         if (opts.presetClass) currentCallout.classList.add(opts.presetClass);
         currentCallout.style.backgroundColor = opts.backgroundColor;
-        currentCallout.style.borderColor = opts.borderColor;
-        currentCallout.style.borderWidth = opts.borderWidth + 'px';
-        currentCallout.style.borderRadius = opts.borderRadius + 'px';
-        currentCallout.style.padding = opts.padding + 'px';
-        currentCallout.style.margin = opts.margin + 'px 0';
+        currentCallout.style.border = 'none';
+        currentCallout.style.borderLeft = `${opts.borderWidth}px solid ${opts.borderColor}`;
+        currentCallout.style.borderRadius = `${opts.borderRadius}px`;
+        currentCallout.style.padding = `${opts.padding}px`;
+        currentCallout.style.margin = `${opts.margin}px 0`;
+        currentCallout.classList.add('note-resizable');
         if (opts.shadow) {
             currentCallout.classList.add('note-shadow');
         } else {
@@ -3773,6 +3805,8 @@ document.addEventListener('DOMContentLoaded', function () {
         notesEditor.focus();
         closeNoteStyleModal();
     }
+
+    renderNotePresets();
 
 
     function resizeSelectedImage(multiplier) {
@@ -5996,27 +6030,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 shadow: noteShadowInput.checked
             };
             applyNoteStyle(opts);
-        });
-        noteStyleModal.querySelectorAll('.predef-note-btn').forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                e.preventDefault();
-                const opts = {
-                    backgroundColor: btn.dataset.bg,
-                    borderColor: btn.dataset.border,
-                    borderRadius: 8,
-                    borderWidth: 2,
-                    padding: 8,
-                    margin: 8,
-                    shadow: false,
-                    presetClass: btn.classList.contains('note-blue') ? 'note-blue' :
-                                 btn.classList.contains('note-green') ? 'note-green' :
-                                 btn.classList.contains('note-yellow') ? 'note-yellow' :
-                                 btn.classList.contains('note-red') ? 'note-red' :
-                                 btn.classList.contains('note-purple') ? 'note-purple' :
-                                 btn.classList.contains('note-gray') ? 'note-gray' : null
-                };
-                applyNoteStyle(opts);
-            });
         });
 
         // --- Quick Note Modal Listeners ---


### PR DESCRIPTION
## Summary
- allow inserting notes with configurable presets
- support editing note colors and resizable left-border callouts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6e52716dc832c85c8de5855073235