### PR TITLE
feat: expand note styles with customizable accents

### DIFF
--- a/index.css
+++ b/index.css
@@ -864,19 +864,25 @@ table.resizable-table.selected .table-resize-handle {
 
 /* Note callout styles */
 .note-callout {
+    --background-color: #fff;
+    --border-color: #ccc;
+    --accent-color: var(--border-color);
+    --text-color: #000;
+    font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+    font-size: 13px;
+    line-height: 1.1;
     border-radius: 8px;
-    border: 2px solid var(--border-color);
-    padding: 8px;
-    margin: 8px 0;
+    border: 1px solid var(--border-color);
+    padding: 10px 12px;
+    margin: 20px 0;
+    background: var(--background-color);
+    color: var(--text-color);
 }
-.note-callout-content {
-    outline: none;
-}
+.note-callout h4 { margin:0 0 6px 0; font-size:14px; }
+.note-callout-content { outline: none; }
 .note-callout ul,
-.note-callout ol {
-    margin: 0;
-    padding-left: 1.25rem;
-}
+.note-callout ol { margin: 0; padding-left: 1.25rem; }
+.muted { opacity:.85; }
 
 /* Indentation levels applied via classes instead of inline spaces */
 .indent-1 { margin-left: 1rem; }
@@ -957,12 +963,100 @@ table.resizable-table.selected .table-resize-handle {
     display: inline-block;
     max-width: 100%;
 }
-.note-blue { background-color: #dbeafe; border-color: #3b82f6; }
-.note-green { background-color: #d1fae5; border-color: #10b981; }
-.note-yellow { background-color: #fef9c3; border-color: #eab308; }
-.note-red { background-color: #fee2e2; border-color: #ef4444; }
-.note-purple { background-color: #ede9fe; border-color: #8b5cf6; }
-.note-gray { background-color: #f3f4f6; border-color: #6b7280; }
+.note-blue-left {
+    --background-color: #f7fcff;
+    --border-color: #b3e5fc;
+    --text-color: #0d47a1;
+    border: none;
+    border-left: 6px solid var(--border-color);
+}
+.note-green-card {
+    --background-color: #fbfffb;
+    --border-color: #c8e6c9;
+    --text-color: #1b5e20;
+    border: 1px solid var(--border-color);
+}
+.note-lila-dotted {
+    --background-color: #fcfbff;
+    --border-color: #d1c4e9;
+    --text-color: #512da8;
+    border: 2px dotted var(--border-color);
+}
+.note-durazno-dashed {
+    --background-color: #fffaf7;
+    --border-color: #ffccbc;
+    --text-color: #e65100;
+    border: 2px dashed var(--border-color);
+}
+.note-cian-top {
+    --background-color: #f8ffff;
+    --border-color: #b2ebf2;
+    --text-color: #006064;
+    border: none;
+    border-top: 6px solid var(--border-color);
+}
+.note-rosado-double {
+    --background-color: #fff8fb;
+    --border-color: #f8bbd0;
+    --text-color: #ad1457;
+    border: none;
+    border-left: 8px double var(--border-color);
+}
+.note-amarillo-corner {
+    --background-color: #fffffb;
+    --border-color: #fff9c4;
+    --accent-color: #fff59d;
+    --text-color: #7a6e00;
+    border: 1px solid var(--border-color);
+    position: relative;
+}
+.note-amarillo-corner::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-top: 6px solid var(--accent-color);
+    border-left: 6px solid var(--accent-color);
+    border-radius: 8px 0 0 0;
+    pointer-events: none;
+}
+.note-gradient {
+    --background-color: #ffffff;
+    --border-color: #b3e5fc;
+    --accent-color: #d1c4e9;
+    --text-color: #4a148c;
+    border: 1px solid var(--border-color);
+    position: relative;
+    overflow: hidden;
+}
+.note-gradient::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 6px;
+    background: linear-gradient(180deg, var(--border-color), var(--accent-color));
+}
+.note-menta-bottom {
+    --background-color: #fbfffb;
+    --border-color: #c8e6c9;
+    --text-color: #1b5e20;
+    border: none;
+    border-bottom: 6px solid var(--border-color);
+}
+.note-violeta-shadow {
+    --background-color: #fdfcff;
+    --border-color: #e6e0f8;
+    --text-color: #4a148c;
+    border: 1px solid var(--border-color);
+    box-shadow: 0 1px 3px rgba(0,0,0,.03);
+}
+.note-gray-neutral {
+    --background-color: #f9f9f9;
+    --border-color: #e0e0e0;
+    --text-color: #424242;
+    border: 1px solid var(--border-color);
+}
 .note-shadow { box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
 .predef-note-btn { margin:0; cursor:pointer; }
 

--- a/index.html
+++ b/index.html
@@ -607,22 +607,17 @@
                 <button id="note-style-tab-custom" class="flex-1 p-1">Personalizado</button>
             </div>
             <div id="note-style-pre" class="space-y-2">
-                <div class="grid grid-cols-2 gap-2">
-                    <button class="predef-note-btn note-callout note-blue" data-bg="#dbeafe" data-border="#3b82f6">Azul</button>
-                    <button class="predef-note-btn note-callout note-green" data-bg="#d1fae5" data-border="#10b981">Verde</button>
-                    <button class="predef-note-btn note-callout note-yellow" data-bg="#fef9c3" data-border="#eab308">Amarillo</button>
-                    <button class="predef-note-btn note-callout note-red" data-bg="#fee2e2" data-border="#ef4444">Rojo</button>
-                    <button class="predef-note-btn note-callout note-purple" data-bg="#ede9fe" data-border="#8b5cf6">Morado</button>
-                    <button class="predef-note-btn note-callout note-gray" data-bg="#f3f4f6" data-border="#6b7280">Gris</button>
-                </div>
+                <!-- Botones de estilos predefinidos generados por script -->
             </div>
             <div id="note-style-custom" class="hidden space-y-2">
                 <label class="flex items-center justify-between">Fondo <input type="color" id="note-bg-color" value="#ffffff" class="border"></label>
                 <label class="flex items-center justify-between">Borde <input type="color" id="note-border-color" value="#000000" class="border"></label>
+                <label class="flex items-center justify-between">Borde especial <input type="color" id="note-accent-color" value="#000000" class="border"></label>
+                <label class="flex items-center justify-between">Texto <input type="color" id="note-text-color" value="#000000" class="border"></label>
                 <label class="flex items-center justify-between">Radio <input type="number" id="note-radius" value="8" class="w-16 border"></label>
-                <label class="flex items-center justify-between">Espesor <input type="number" id="note-border-width" value="2" class="w-16 border"></label>
-                <label class="flex items-center justify-between">Padding <input type="number" id="note-padding" value="8" class="w-16 border"></label>
-                <label class="flex items-center justify-between">Margen vertical <input type="number" id="note-margin" value="8" class="w-16 border"></label>
+                <label class="flex items-center justify-between">Espesor <input type="number" id="note-border-width" value="1" class="w-16 border"></label>
+                <label class="flex items-center justify-between">Padding <input type="number" id="note-padding" value="10" class="w-16 border"></label>
+                <label class="flex items-center justify-between">Margen vertical <input type="number" id="note-margin" value="20" class="w-16 border"></label>
                 <label class="flex items-center justify-between"><span>Sombra</span><input type="checkbox" id="note-shadow"></label>
             </div>
             <div class="flex justify-end gap-2 mt-3">


### PR DESCRIPTION
## Summary
- add pastel note presets with varied borders and accents
- allow editing accent colors alongside background, border, and text
- refactor note styling to use CSS variables for easy extension

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e52716dc832c85c8de5855073235