### PR TITLE
feat: add pastel note styles with customizable borders

### DIFF
--- a/index.css
+++ b/index.css
@@ -957,13 +957,103 @@ table.resizable-table.selected .table-resize-handle {
     display: inline-block;
     max-width: 100%;
 }
-.note-blue { background-color: #dbeafe; border-color: #3b82f6; }
-.note-green { background-color: #d1fae5; border-color: #10b981; }
-.note-yellow { background-color: #fef9c3; border-color: #eab308; }
-.note-red { background-color: #fee2e2; border-color: #ef4444; }
-.note-purple { background-color: #ede9fe; border-color: #8b5cf6; }
-.note-gray { background-color: #f3f4f6; border-color: #6b7280; }
-.note-shadow { box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+.note-shadow { box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+
+/* Pastel note presets */
+.note-azul-suave {
+    background:#f7fcff;
+    --border-color:#b3e5fc;
+    border-width:0;
+    border-left:6px solid var(--border-color);
+    color:#000;
+}
+.note-verde-pastel {
+    background:#fbfffb;
+    --border-color:#c8e6c9;
+    border:1px solid var(--border-color);
+    color:#000;
+}
+.note-lila-punteada {
+    background:#fcfbff;
+    --border-color:#d1c4e9;
+    border:2px dotted var(--border-color);
+    color:#000;
+}
+.note-durazno {
+    background:#fffaf7;
+    --border-color:#ffccbc;
+    border:2px dashed var(--border-color);
+    color:#000;
+}
+.note-banda-superior {
+    background:#f8ffff;
+    --border-color:#b2ebf2;
+    border-width:0;
+    border-top:6px solid var(--border-color);
+    color:#000;
+}
+.note-rosa-doble {
+    background:#fff8fb;
+    --border-color:#f8bbd0;
+    border-width:0;
+    border-left:8px double var(--border-color);
+    color:#000;
+}
+.note-esquina-amarilla {
+    background:#fffffb;
+    --border-color:#fff9c4;
+    border:1px solid var(--border-color);
+    position:relative;
+    color:#000;
+    --accent-color:#fff59d;
+}
+.note-esquina-amarilla::before {
+    content:'';
+    position:absolute;
+    inset:0;
+    border-top:6px solid var(--accent-color);
+    border-left:6px solid var(--accent-color);
+    border-radius:8px 0 0 0;
+    pointer-events:none;
+}
+.note-borde-degradado {
+    background:#ffffff;
+    --border-color:#ede7f6;
+    border:1px solid var(--border-color);
+    position:relative;
+    overflow:hidden;
+    color:#000;
+    --grad-color1:#b3e5fc;
+    --grad-color2:#d1c4e9;
+}
+.note-borde-degradado::before {
+    content:'';
+    position:absolute;
+    left:0;
+    top:0;
+    bottom:0;
+    width:6px;
+    background:linear-gradient(180deg,var(--grad-color1),var(--grad-color2));
+}
+.note-menta-inferior {
+    background:#fbfffb;
+    --border-color:#c8e6c9;
+    border-width:0;
+    border-bottom:6px solid var(--border-color);
+    color:#000;
+}
+.note-violeta-sombra {
+    background:#fdfcff;
+    --border-color:#e6e0f8;
+    border:1px solid var(--border-color);
+    color:#000;
+}
+.note-gris-neutral {
+    background:#f9f9f9;
+    --border-color:#e0e0e0;
+    border:1px solid var(--border-color);
+    color:#000;
+}
 .predef-note-btn { margin:0; cursor:pointer; }
 
 /* Ensure HTML code modal appears above other dialogs */

--- a/index.html
+++ b/index.html
@@ -607,20 +607,31 @@
                 <button id="note-style-tab-custom" class="flex-1 p-1">Personalizado</button>
             </div>
             <div id="note-style-pre" class="space-y-2">
-                <div class="grid grid-cols-2 gap-2">
-                    <button class="predef-note-btn note-callout note-blue" data-bg="#dbeafe" data-border="#3b82f6">Azul</button>
-                    <button class="predef-note-btn note-callout note-green" data-bg="#d1fae5" data-border="#10b981">Verde</button>
-                    <button class="predef-note-btn note-callout note-yellow" data-bg="#fef9c3" data-border="#eab308">Amarillo</button>
-                    <button class="predef-note-btn note-callout note-red" data-bg="#fee2e2" data-border="#ef4444">Rojo</button>
-                    <button class="predef-note-btn note-callout note-purple" data-bg="#ede9fe" data-border="#8b5cf6">Morado</button>
-                    <button class="predef-note-btn note-callout note-gray" data-bg="#f3f4f6" data-border="#6b7280">Gris</button>
-                </div>
+                <!-- Botones de estilos predefinidos generados por script -->
             </div>
             <div id="note-style-custom" class="hidden space-y-2">
                 <label class="flex items-center justify-between">Fondo <input type="color" id="note-bg-color" value="#ffffff" class="border"></label>
                 <label class="flex items-center justify-between">Borde <input type="color" id="note-border-color" value="#000000" class="border"></label>
+                <label class="flex items-center justify-between">Texto <input type="color" id="note-text-color" value="#000000" class="border"></label>
                 <label class="flex items-center justify-between">Radio <input type="number" id="note-radius" value="8" class="w-16 border"></label>
                 <label class="flex items-center justify-between">Espesor <input type="number" id="note-border-width" value="2" class="w-16 border"></label>
+                <label class="flex items-center justify-between">Estilo de borde
+                    <select id="note-border-style" class="w-24 border">
+                        <option value="solid">Sólido</option>
+                        <option value="dotted">Punteado</option>
+                        <option value="dashed">Discontinuo</option>
+                        <option value="double">Doble</option>
+                    </select>
+                </label>
+                <label class="flex items-center justify-between">Lado del borde
+                    <select id="note-border-side" class="w-24 border">
+                        <option value="all">Completo</option>
+                        <option value="left">Izquierda</option>
+                        <option value="right">Derecha</option>
+                        <option value="top">Superior</option>
+                        <option value="bottom">Inferior</option>
+                    </select>
+                </label>
                 <label class="flex items-center justify-between">Padding <input type="number" id="note-padding" value="8" class="w-16 border"></label>
                 <label class="flex items-center justify-between">Margen vertical <input type="number" id="note-margin" value="8" class="w-16 border"></label>
                 <label class="flex items-center justify-between"><span>Sombra</span><input type="checkbox" id="note-shadow"></label>

--- a/index.js
+++ b/index.js
@@ -618,13 +618,56 @@ document.addEventListener('DOMContentLoaded', function () {
     const noteStyleCustom = getElem('note-style-custom');
     const noteBgColorInput = getElem('note-bg-color');
     const noteBorderColorInput = getElem('note-border-color');
+    const noteTextColorInput = getElem('note-text-color');
     const noteRadiusInput = getElem('note-radius');
     const noteBorderWidthInput = getElem('note-border-width');
+    const noteBorderStyleInput = getElem('note-border-style');
+    const noteBorderSideInput = getElem('note-border-side');
     const notePaddingInput = getElem('note-padding');
     const noteMarginInput = getElem('note-margin');
     const noteShadowInput = getElem('note-shadow');
     const applyNoteStyleBtn = getElem('apply-note-style-btn');
     const cancelNoteStyleBtn = getElem('cancel-note-style-btn');
+
+    const NOTE_PRESETS = [
+        { name: 'Azul suave', class: 'note-azul-suave', bg: '#f7fcff', border: '#b3e5fc', text: '#000000', borderWidth: 6, borderStyle: 'solid', borderSide: 'left' },
+        { name: 'Verde pastel', class: 'note-verde-pastel', bg: '#fbfffb', border: '#c8e6c9', text: '#000000', borderWidth: 1, borderStyle: 'solid', borderSide: 'all' },
+        { name: 'Lila punteada', class: 'note-lila-punteada', bg: '#fcfbff', border: '#d1c4e9', text: '#000000', borderWidth: 2, borderStyle: 'dotted', borderSide: 'all' },
+        { name: 'Durazno', class: 'note-durazno', bg: '#fffaf7', border: '#ffccbc', text: '#000000', borderWidth: 2, borderStyle: 'dashed', borderSide: 'all' },
+        { name: 'Banda superior', class: 'note-banda-superior', bg: '#f8ffff', border: '#b2ebf2', text: '#000000', borderWidth: 6, borderStyle: 'solid', borderSide: 'top' },
+        { name: 'Rosa doble', class: 'note-rosa-doble', bg: '#fff8fb', border: '#f8bbd0', text: '#000000', borderWidth: 8, borderStyle: 'double', borderSide: 'left' },
+        { name: 'Esquina acentuada', class: 'note-esquina-amarilla', bg: '#fffffb', border: '#fff9c4', text: '#000000', borderWidth: 1, borderStyle: 'solid', borderSide: 'all', accentColor: '#fff59d' },
+        { name: 'Borde degradado', class: 'note-borde-degradado', bg: '#ffffff', border: '#ede7f6', text: '#000000', borderWidth: 1, borderStyle: 'solid', borderSide: 'all', grad1: '#b3e5fc', grad2: '#d1c4e9' },
+        { name: 'Menta inferior', class: 'note-menta-inferior', bg: '#fbfffb', border: '#c8e6c9', text: '#000000', borderWidth: 6, borderStyle: 'solid', borderSide: 'bottom' },
+        { name: 'Violeta sombra', class: 'note-violeta-sombra', bg: '#fdfcff', border: '#e6e0f8', text: '#000000', borderWidth: 1, borderStyle: 'solid', borderSide: 'all', shadow: true },
+        { name: 'Gris', class: 'note-gris-neutral', bg: '#f9f9f9', border: '#e0e0e0', text: '#000000', borderWidth: 1, borderStyle: 'solid', borderSide: 'all' }
+    ];
+
+    function renderNotePresetButtons() {
+        noteStylePre.innerHTML = '';
+        const grid = document.createElement('div');
+        grid.className = 'grid grid-cols-2 gap-2';
+        NOTE_PRESETS.forEach(preset => {
+            const btn = document.createElement('button');
+            btn.className = `predef-note-btn note-callout ${preset.class}${preset.shadow ? ' note-shadow' : ''}`;
+            btn.textContent = preset.name;
+            btn.dataset.bg = preset.bg;
+            btn.dataset.border = preset.border;
+            btn.dataset.text = preset.text;
+            btn.dataset.presetClass = preset.class;
+            btn.dataset.borderWidth = preset.borderWidth;
+            btn.dataset.borderStyle = preset.borderStyle;
+            btn.dataset.borderSide = preset.borderSide;
+            if (preset.shadow) btn.dataset.shadow = 'true';
+            if (preset.accentColor) btn.dataset.accent = preset.accentColor;
+            if (preset.grad1) btn.dataset.grad1 = preset.grad1;
+            if (preset.grad2) btn.dataset.grad2 = preset.grad2;
+            grid.appendChild(btn);
+        });
+        noteStylePre.appendChild(grid);
+    }
+
+    renderNotePresetButtons();
 
     /*
      * Build the simplified toolbar for sub-note editing.  This toolbar intentionally omits
@@ -3551,7 +3594,36 @@ document.addEventListener('DOMContentLoaded', function () {
             delete el._leftResizeHandlers;
         };
 
-        const calloutBtn = createButton('Nota', '💬', null, null, () => {
+        const defaultPreset = NOTE_PRESETS[0];
+        const insertCallout = () => {
+            const selection = window.getSelection();
+            if (selection && selection.rangeCount > 0) {
+                savedEditorSelection = selection.getRangeAt(0).cloneRange();
+            } else {
+                savedEditorSelection = null;
+            }
+            currentCallout = null;
+            applyNoteStyle({
+                presetClass: defaultPreset.class,
+                backgroundColor: defaultPreset.bg,
+                borderColor: defaultPreset.border,
+                textColor: defaultPreset.text,
+                borderRadius: 8,
+                borderWidth: defaultPreset.borderWidth,
+                borderStyle: defaultPreset.borderStyle,
+                borderSide: defaultPreset.borderSide,
+                padding: 8,
+                margin: 8,
+                shadow: !!defaultPreset.shadow,
+                accentColor: defaultPreset.accentColor,
+                grad1: defaultPreset.grad1,
+                grad2: defaultPreset.grad2
+            });
+        };
+        const calloutBtn = createButton('Nota', '💬', null, null, insertCallout);
+        editorToolbar.appendChild(calloutBtn);
+
+        const noteStyleBtn = createButton('Estilo de nota', '🎨', null, null, () => {
             const selection = window.getSelection();
             if (selection && selection.rangeCount > 0) {
                 savedEditorSelection = selection.getRangeAt(0).cloneRange();
@@ -3560,7 +3632,7 @@ document.addEventListener('DOMContentLoaded', function () {
             }
             openNoteStyleModal();
         });
-        editorToolbar.appendChild(calloutBtn);
+        editorToolbar.appendChild(noteStyleBtn);
 
         const resizeCalloutBtn = createButton('Redimensionar nota', '↔️', null, null, () => {
             const selection = window.getSelection();
@@ -3700,8 +3772,21 @@ document.addEventListener('DOMContentLoaded', function () {
         if (callout) {
             noteBgColorInput.value = rgbToHex(callout.style.backgroundColor || '#ffffff');
             noteBorderColorInput.value = rgbToHex(callout.style.borderColor || '#000000');
+            noteTextColorInput.value = rgbToHex(callout.style.color || '#000000');
             noteRadiusInput.value = parseInt(callout.style.borderRadius) || 8;
-            noteBorderWidthInput.value = parseInt(callout.style.borderWidth) || 2;
+            noteBorderStyleInput.value = callout.style.borderStyle || 'solid';
+            let side = 'all';
+            if (parseInt(callout.style.borderLeftWidth)) side = 'left';
+            else if (parseInt(callout.style.borderRightWidth)) side = 'right';
+            else if (parseInt(callout.style.borderTopWidth)) side = 'top';
+            else if (parseInt(callout.style.borderBottomWidth)) side = 'bottom';
+            noteBorderSideInput.value = side;
+            let bw = parseInt(callout.style.borderWidth);
+            if (!bw) {
+                const prop = 'border' + side.charAt(0).toUpperCase() + side.slice(1) + 'Width';
+                bw = parseInt(callout.style[prop]);
+            }
+            noteBorderWidthInput.value = bw || 2;
             notePaddingInput.value = parseInt(callout.style.padding) || 8;
             noteMarginInput.value = parseInt(callout.style.marginTop) || 8;
             noteShadowInput.checked = callout.classList.contains('note-shadow');
@@ -3714,10 +3799,10 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     function applyNoteStyle(opts) {
-        const PREDEF_CLASSES = ['note-blue','note-green','note-yellow','note-red','note-purple','note-gray'];
+        const PREDEF_CLASSES = NOTE_PRESETS.map(p => p.class);
         if (!currentCallout) {
             const callout = document.createElement('div');
-            callout.className = 'note-callout';
+            callout.className = 'note-callout note-resizable';
             callout.setAttribute('role','note');
             callout.setAttribute('aria-label','Nota');
             if (savedEditorSelection && !savedEditorSelection.collapsed) {
@@ -3752,12 +3837,32 @@ document.addEventListener('DOMContentLoaded', function () {
         currentCallout.contentEditable = 'false';
         currentCallout.classList.remove(...PREDEF_CLASSES);
         if (opts.presetClass) currentCallout.classList.add(opts.presetClass);
+        currentCallout.classList.add('note-resizable');
         currentCallout.style.backgroundColor = opts.backgroundColor;
-        currentCallout.style.borderColor = opts.borderColor;
-        currentCallout.style.borderWidth = opts.borderWidth + 'px';
         currentCallout.style.borderRadius = opts.borderRadius + 'px';
+        currentCallout.style.borderStyle = opts.borderStyle || 'solid';
+        if (opts.borderSide && opts.borderSide !== 'all') {
+            currentCallout.style.borderWidth = '0';
+            currentCallout.style.borderColor = 'transparent';
+            const side = opts.borderSide.charAt(0).toUpperCase() + opts.borderSide.slice(1);
+            currentCallout.style['border' + side + 'Width'] = opts.borderWidth + 'px';
+            currentCallout.style['border' + side + 'Color'] = opts.borderColor;
+            currentCallout.style['border' + side + 'Style'] = opts.borderStyle || 'solid';
+        } else {
+            currentCallout.style.borderWidth = opts.borderWidth + 'px';
+            currentCallout.style.borderColor = opts.borderColor;
+        }
         currentCallout.style.padding = opts.padding + 'px';
         currentCallout.style.margin = opts.margin + 'px 0';
+        if (opts.accentColor) currentCallout.style.setProperty('--accent-color', opts.accentColor);
+        else currentCallout.style.removeProperty('--accent-color');
+        if (opts.grad1) currentCallout.style.setProperty('--grad-color1', opts.grad1);
+        else currentCallout.style.removeProperty('--grad-color1');
+        if (opts.grad2) currentCallout.style.setProperty('--grad-color2', opts.grad2);
+        else currentCallout.style.removeProperty('--grad-color2');
+        if (opts.textColor) {
+            currentCallout.style.color = opts.textColor;
+        }
         if (opts.shadow) {
             currentCallout.classList.add('note-shadow');
         } else {
@@ -5989,34 +6094,38 @@ document.addEventListener('DOMContentLoaded', function () {
             const opts = {
                 backgroundColor: noteBgColorInput.value,
                 borderColor: noteBorderColorInput.value,
+                textColor: noteTextColorInput.value,
                 borderRadius: parseInt(noteRadiusInput.value) || 0,
                 borderWidth: parseInt(noteBorderWidthInput.value) || 0,
+                borderStyle: noteBorderStyleInput.value,
+                borderSide: noteBorderSideInput.value,
                 padding: parseInt(notePaddingInput.value) || 0,
                 margin: parseInt(noteMarginInput.value) || 0,
                 shadow: noteShadowInput.checked
             };
             applyNoteStyle(opts);
         });
-        noteStyleModal.querySelectorAll('.predef-note-btn').forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                e.preventDefault();
-                const opts = {
-                    backgroundColor: btn.dataset.bg,
-                    borderColor: btn.dataset.border,
-                    borderRadius: 8,
-                    borderWidth: 2,
-                    padding: 8,
-                    margin: 8,
-                    shadow: false,
-                    presetClass: btn.classList.contains('note-blue') ? 'note-blue' :
-                                 btn.classList.contains('note-green') ? 'note-green' :
-                                 btn.classList.contains('note-yellow') ? 'note-yellow' :
-                                 btn.classList.contains('note-red') ? 'note-red' :
-                                 btn.classList.contains('note-purple') ? 'note-purple' :
-                                 btn.classList.contains('note-gray') ? 'note-gray' : null
-                };
-                applyNoteStyle(opts);
-            });
+        noteStylePre.addEventListener('click', (e) => {
+            const btn = e.target.closest('.predef-note-btn');
+            if (!btn) return;
+            e.preventDefault();
+            const opts = {
+                backgroundColor: btn.dataset.bg,
+                borderColor: btn.dataset.border,
+                textColor: btn.dataset.text,
+                borderRadius: 8,
+                borderWidth: parseInt(btn.dataset.borderWidth) || 0,
+                borderStyle: btn.dataset.borderStyle || 'solid',
+                borderSide: btn.dataset.borderSide || 'all',
+                padding: 8,
+                margin: 8,
+                shadow: btn.dataset.shadow === 'true',
+                presetClass: btn.dataset.presetClass || null,
+                accentColor: btn.dataset.accent || null,
+                grad1: btn.dataset.grad1 || null,
+                grad2: btn.dataset.grad2 || null
+            };
+            applyNoteStyle(opts);
         });
 
         // --- Quick Note Modal Listeners ---


### PR DESCRIPTION
## Summary
- include border side and style controls in note-style modal for flexible color editing
- add 11 pastel note presets with options like dotted, dashed, double and accented borders
- apply selected note styles with support for side-specific borders and optional shadows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e52716dc832c85c8de5855073235