### PR TITLE
feat: add customizable note styles

### DIFF
--- a/index.css
+++ b/index.css
@@ -866,8 +866,8 @@ table.resizable-table.selected .table-resize-handle {
 .note-callout {
     border-radius: 8px;
     border: 2px solid var(--border-color);
-    padding: 8px;
-    margin: 8px 0;
+    padding: 10px 12px;
+    margin: 20px 0;
 }
 .note-callout-content {
     outline: none;
@@ -876,6 +876,88 @@ table.resizable-table.selected .table-resize-handle {
 .note-callout ol {
     margin: 0;
     padding-left: 1.25rem;
+}
+
+/* Pastel note style presets */
+.note-blue-left {
+    border: none;
+    border-left: 6px solid #b3e5fc;
+    background: #f7fcff;
+}
+
+.note-green-card {
+    border: 1px solid #c8e6c9;
+    background: #fbfffb;
+}
+
+.note-lilac-dotted {
+    border: 2px dotted #d1c4e9;
+    background: #fcfbff;
+}
+
+.note-peach-dashed {
+    border: 2px dashed #ffccbc;
+    background: #fffaf7;
+}
+
+.note-cyan-top {
+    border: none;
+    border-top: 6px solid #b2ebf2;
+    background: #f8ffff;
+}
+
+.note-pink-double-left {
+    border: none;
+    border-left: 8px double #f8bbd0;
+    background: #fff8fb;
+}
+
+.note-yellow-corner {
+    position: relative;
+    border: 1px solid #fff9c4;
+    background: #fffffb;
+}
+.note-yellow-corner::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-top: 6px solid var(--accent-color, #fff59d);
+    border-left: 6px solid var(--accent-color, #fff59d);
+    border-radius: 8px 0 0 0;
+    pointer-events: none;
+}
+
+.note-gradient {
+    position: relative;
+    border: 1px solid #ede7f6;
+    background: #ffffff;
+    overflow: hidden;
+}
+.note-gradient::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 6px;
+    background: linear-gradient(180deg, var(--gradient-start, #b3e5fc), var(--gradient-end, #d1c4e9));
+}
+
+.note-mint-bottom {
+    border: none;
+    border-bottom: 6px solid #c8e6c9;
+    background: #fbfffb;
+}
+
+.note-violet-soft {
+    border: 1px solid #e6e0f8;
+    background: #fdfcff;
+    box-shadow: 0 1px 3px rgba(0,0,0,.03);
+}
+
+.note-gray-neutral {
+    border: 1px solid #e0e0e0;
+    background: #f9f9f9;
 }
 
 /* Indentation levels applied via classes instead of inline spaces */
@@ -957,12 +1039,12 @@ table.resizable-table.selected .table-resize-handle {
     display: inline-block;
     max-width: 100%;
 }
-.note-blue { background-color: #dbeafe; border-color: #3b82f6; }
-.note-green { background-color: #d1fae5; border-color: #10b981; }
-.note-yellow { background-color: #fef9c3; border-color: #eab308; }
-.note-red { background-color: #fee2e2; border-color: #ef4444; }
-.note-purple { background-color: #ede9fe; border-color: #8b5cf6; }
-.note-gray { background-color: #f3f4f6; border-color: #6b7280; }
+.note-blue { background-color: #dbeafe; border-color: #3b82f6; color: #1e3a8a; }
+.note-green { background-color: #d1fae5; border-color: #10b981; color: #065f46; }
+.note-yellow { background-color: #fef9c3; border-color: #eab308; color: #92400e; }
+.note-red { background-color: #fee2e2; border-color: #ef4444; color: #991b1b; }
+.note-purple { background-color: #ede9fe; border-color: #8b5cf6; color: #5b21b6; }
+.note-gray { background-color: #f3f4f6; border-color: #6b7280; color: #374151; }
 .note-shadow { box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
 .predef-note-btn { margin:0; cursor:pointer; }
 

--- a/index.html
+++ b/index.html
@@ -607,22 +607,19 @@
                 <button id="note-style-tab-custom" class="flex-1 p-1">Personalizado</button>
             </div>
             <div id="note-style-pre" class="space-y-2">
-                <div class="grid grid-cols-2 gap-2">
-                    <button class="predef-note-btn note-callout note-blue" data-bg="#dbeafe" data-border="#3b82f6">Azul</button>
-                    <button class="predef-note-btn note-callout note-green" data-bg="#d1fae5" data-border="#10b981">Verde</button>
-                    <button class="predef-note-btn note-callout note-yellow" data-bg="#fef9c3" data-border="#eab308">Amarillo</button>
-                    <button class="predef-note-btn note-callout note-red" data-bg="#fee2e2" data-border="#ef4444">Rojo</button>
-                    <button class="predef-note-btn note-callout note-purple" data-bg="#ede9fe" data-border="#8b5cf6">Morado</button>
-                    <button class="predef-note-btn note-callout note-gray" data-bg="#f3f4f6" data-border="#6b7280">Gris</button>
-                </div>
+                <!-- Botones de estilos predefinidos generados por script -->
             </div>
             <div id="note-style-custom" class="hidden space-y-2">
-                <label class="flex items-center justify-between">Fondo <input type="color" id="note-bg-color" value="#ffffff" class="border"></label>
-                <label class="flex items-center justify-between">Borde <input type="color" id="note-border-color" value="#000000" class="border"></label>
+                <div class="flex items-center justify-between"><span>Fondo</span><div id="note-bg-color-palette"></div></div>
+                <div class="flex items-center justify-between"><span>Borde</span><div id="note-border-color-palette"></div></div>
+                <div class="flex items-center justify-between"><span>Texto</span><div id="note-text-color-palette"></div></div>
+                <input type="color" id="note-bg-color" value="#ffffff" class="hidden">
+                <input type="color" id="note-border-color" value="#000000" class="hidden">
+                <input type="color" id="note-text-color" value="#000000" class="hidden">
                 <label class="flex items-center justify-between">Radio <input type="number" id="note-radius" value="8" class="w-16 border"></label>
                 <label class="flex items-center justify-between">Espesor <input type="number" id="note-border-width" value="2" class="w-16 border"></label>
-                <label class="flex items-center justify-between">Padding <input type="number" id="note-padding" value="8" class="w-16 border"></label>
-                <label class="flex items-center justify-between">Margen vertical <input type="number" id="note-margin" value="8" class="w-16 border"></label>
+                <label class="flex items-center justify-between">Padding <input type="number" id="note-padding" value="12" class="w-16 border"></label>
+                <label class="flex items-center justify-between">Margen vertical <input type="number" id="note-margin" value="20" class="w-16 border"></label>
                 <label class="flex items-center justify-between"><span>Sombra</span><input type="checkbox" id="note-shadow"></label>
             </div>
             <div class="flex justify-end gap-2 mt-3">

--- a/index.js
+++ b/index.js
@@ -618,6 +618,10 @@ document.addEventListener('DOMContentLoaded', function () {
     const noteStyleCustom = getElem('note-style-custom');
     const noteBgColorInput = getElem('note-bg-color');
     const noteBorderColorInput = getElem('note-border-color');
+    const noteTextColorInput = getElem('note-text-color');
+    const noteBgColorPicker = getElem('note-bg-color-palette');
+    const noteBorderColorPicker = getElem('note-border-color-palette');
+    const noteTextColorPicker = getElem('note-text-color-palette');
     const noteRadiusInput = getElem('note-radius');
     const noteBorderWidthInput = getElem('note-border-width');
     const notePaddingInput = getElem('note-padding');
@@ -625,6 +629,117 @@ document.addEventListener('DOMContentLoaded', function () {
     const noteShadowInput = getElem('note-shadow');
     const applyNoteStyleBtn = getElem('apply-note-style-btn');
     const cancelNoteStyleBtn = getElem('cancel-note-style-btn');
+
+    const NOTE_PRESETS = [
+        { name: 'Nota Azul Suave', class: 'note-blue-left', bg: '#f7fcff', border: '#b3e5fc', text: '#0c4a6e' },
+        { name: 'Nota Verde Pastel', class: 'note-green-card', bg: '#fbfffb', border: '#c8e6c9', text: '#1b5e20', borderWidth: 1 },
+        { name: 'Nota Lila Punteada', class: 'note-lilac-dotted', bg: '#fcfbff', border: '#d1c4e9', text: '#4a148c', borderWidth: 2 },
+        { name: 'Nota Durazno', class: 'note-peach-dashed', bg: '#fffaf7', border: '#ffccbc', text: '#bf360c', borderWidth: 2 },
+        { name: 'Nota Banda Superior', class: 'note-cyan-top', bg: '#f8ffff', border: '#b2ebf2', text: '#006064' },
+        { name: 'Nota Rosa Doble', class: 'note-pink-double-left', bg: '#fff8fb', border: '#f8bbd0', text: '#880e4f' },
+        { name: 'Nota Esquina Acentuada', class: 'note-yellow-corner', bg: '#fffffb', border: '#fff9c4', text: '#665c00', borderWidth: 1, accent: '#fff59d' },
+        { name: 'Nota Borde Degradado', class: 'note-gradient', bg: '#ffffff', border: '#ede7f6', text: '#4a148c', borderWidth: 1, gradientStart: '#b3e5fc', gradientEnd: '#d1c4e9', padding: 14 },
+        { name: 'Nota Menta Inferior', class: 'note-mint-bottom', bg: '#fbfffb', border: '#c8e6c9', text: '#1b5e20' },
+        { name: 'Nota Violeta Ultraligera', class: 'note-violet-soft', bg: '#fdfcff', border: '#e6e0f8', text: '#4a148c', borderWidth: 1, shadow: false },
+        { name: 'Nota Gris', class: 'note-gray-neutral', bg: '#f9f9f9', border: '#e0e0e0', text: '#424242', borderWidth: 1 }
+    ];
+
+    const NOTE_MAIN_COLORS = ['#FAFAD2'];
+    const NOTE_EXTRA_COLORS = ['transparent', '#FFFFFF', '#FFFF00', '#ADD8E6', '#F0FFF0', '#FFF0F5', '#F5FFFA', '#F0F8FF', '#E6E6FA', '#FFF5EE', '#FAEBD7', '#FFE4E1', '#FFFFE0', '#D3FFD3', '#B0E0E6', '#FFB6C1', '#F5DEB3', '#C8A2C8', '#FFDEAD', '#E0FFFF', '#FDF5E6', '#FFFACD', '#F8F8FF', '#D3D3D3', '#A9A9A9', '#696969', '#C4A484', '#A0522D', '#8B4513'];
+
+    function renderNotePresetButtons() {
+        noteStylePre.innerHTML = '';
+        const grid = document.createElement('div');
+        grid.className = 'grid grid-cols-2 gap-2';
+        NOTE_PRESETS.forEach(preset => {
+            const btn = document.createElement('button');
+            btn.className = `predef-note-btn note-callout ${preset.class}`;
+            btn.textContent = preset.name;
+            btn.dataset.bg = preset.bg;
+            btn.dataset.border = preset.border;
+            btn.dataset.text = preset.text;
+            btn.dataset.radius = preset.radius ?? 8;
+            if (preset.borderWidth !== undefined) btn.dataset.borderWidth = preset.borderWidth;
+            btn.dataset.padding = preset.padding ?? 12;
+            btn.dataset.margin = preset.margin ?? 20;
+            btn.dataset.shadow = preset.shadow ? 'true' : 'false';
+            if (preset.accent) btn.dataset.accent = preset.accent;
+            if (preset.gradientStart) btn.dataset.gradientStart = preset.gradientStart;
+            if (preset.gradientEnd) btn.dataset.gradientEnd = preset.gradientEnd;
+            btn.dataset.presetClass = preset.class;
+            grid.appendChild(btn);
+        });
+        noteStylePre.appendChild(grid);
+    }
+
+    function renderNoteColorPalette(container, inputEl) {
+        container.innerHTML = '';
+        const group = document.createElement('div');
+        group.className = 'color-palette-group';
+        NOTE_MAIN_COLORS.forEach(color => {
+            const sw = document.createElement('button');
+            sw.className = 'color-swatch toolbar-btn';
+            if (color === 'transparent') {
+                sw.style.backgroundImage = 'linear-gradient(to top left, transparent calc(50% - 1px), red, transparent calc(50% + 1px))';
+                sw.style.backgroundColor = 'var(--bg-secondary)';
+                sw.title = 'Sin color';
+            } else {
+                sw.style.backgroundColor = color;
+                sw.title = color;
+            }
+            sw.addEventListener('click', (e) => {
+                e.preventDefault();
+                inputEl.value = color;
+            });
+            group.appendChild(sw);
+        });
+        const otherBtn = document.createElement('button');
+        otherBtn.className = 'other-colors-btn toolbar-btn';
+        otherBtn.textContent = '⋯';
+        group.appendChild(otherBtn);
+        const submenu = document.createElement('div');
+        submenu.className = 'color-submenu';
+        NOTE_EXTRA_COLORS.forEach(color => {
+            const sw = document.createElement('button');
+            sw.className = 'color-swatch';
+            if (color === 'transparent') {
+                sw.style.backgroundImage = 'linear-gradient(to top left, transparent calc(50% - 1px), red, transparent calc(50% + 1px))';
+                sw.style.backgroundColor = 'var(--bg-secondary)';
+                sw.title = 'Sin color';
+            } else {
+                sw.style.backgroundColor = color;
+                sw.title = color;
+            }
+            sw.addEventListener('click', (e) => {
+                e.preventDefault();
+                inputEl.value = color;
+                submenu.classList.remove('visible');
+            });
+            submenu.appendChild(sw);
+        });
+        const customLabel = document.createElement('label');
+        customLabel.className = 'toolbar-btn';
+        customLabel.textContent = '🎨';
+        inputEl.classList.add('hidden');
+        inputEl.style.display = 'none';
+        customLabel.appendChild(inputEl);
+        inputEl.addEventListener('input', (e) => {
+            inputEl.value = e.target.value;
+            submenu.classList.remove('visible');
+        });
+        submenu.appendChild(customLabel);
+        group.appendChild(submenu);
+        otherBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            submenu.classList.toggle('visible');
+        });
+        container.appendChild(group);
+    }
+
+    renderNotePresetButtons();
+    renderNoteColorPalette(noteBgColorPicker, noteBgColorInput);
+    renderNoteColorPalette(noteBorderColorPicker, noteBorderColorInput);
+    renderNoteColorPalette(noteTextColorPicker, noteTextColorInput);
 
     /*
      * Build the simplified toolbar for sub-note editing.  This toolbar intentionally omits
@@ -3121,7 +3236,7 @@ document.addEventListener('DOMContentLoaded', function () {
             { label: 'Morado', class: 'table-theme-purple' },
             { label: 'Turquesa', class: 'table-theme-teal' }
         ];
-        const showTableMenu = (table, cell, x, y) => {
+        const showTableMenu = (table, cell) => {
             currentTable = table;
             tableMenu.innerHTML = '';
 
@@ -3219,8 +3334,13 @@ document.addEventListener('DOMContentLoaded', function () {
             });
 
             tableMenu.style.display = 'block';
-            tableMenu.style.top = `${y}px`;
-            tableMenu.style.left = `${x}px`;
+            const rect = table.getBoundingClientRect();
+            const menuRect = tableMenu.getBoundingClientRect();
+            let top = rect.top + window.scrollY - menuRect.height - 8;
+            if (top < 0) top = rect.bottom + window.scrollY + 8;
+            const left = rect.left + window.scrollX + (rect.width - menuRect.width) / 2;
+            tableMenu.style.top = `${top}px`;
+            tableMenu.style.left = `${left}px`;
             tableMenu.style.zIndex = 10001;
         };
         notesEditor.addEventListener('click', (e) => {
@@ -3228,7 +3348,7 @@ document.addEventListener('DOMContentLoaded', function () {
             const cell = e.target.closest('td, th');
             const table = e.target.closest('table');
             if (table && notesEditor.contains(table)) {
-                showTableMenu(table, cell, e.pageX, e.pageY);
+                showTableMenu(table, cell);
                 e.stopPropagation();
             }
         });
@@ -3551,7 +3671,31 @@ document.addEventListener('DOMContentLoaded', function () {
             delete el._leftResizeHandlers;
         };
 
-        const calloutBtn = createButton('Nota', '💬', null, null, () => {
+        const defaultPreset = NOTE_PRESETS[0];
+        const insertCallout = () => {
+            const selection = window.getSelection();
+            if (selection && selection.rangeCount > 0) {
+                savedEditorSelection = selection.getRangeAt(0).cloneRange();
+            } else {
+                savedEditorSelection = null;
+            }
+            currentCallout = null;
+            applyNoteStyle({
+                presetClass: defaultPreset.class,
+                backgroundColor: defaultPreset.bg,
+                borderColor: defaultPreset.border,
+                textColor: defaultPreset.text,
+                borderRadius: 8,
+                borderWidth: 2,
+                padding: 8,
+                margin: 8,
+                shadow: false
+            });
+        };
+        const calloutBtn = createButton('Nota', '💬', null, null, insertCallout);
+        editorToolbar.appendChild(calloutBtn);
+
+        const noteStyleBtn = createButton('Estilo de nota', '🎨', null, null, () => {
             const selection = window.getSelection();
             if (selection && selection.rangeCount > 0) {
                 savedEditorSelection = selection.getRangeAt(0).cloneRange();
@@ -3560,7 +3704,7 @@ document.addEventListener('DOMContentLoaded', function () {
             }
             openNoteStyleModal();
         });
-        editorToolbar.appendChild(calloutBtn);
+        editorToolbar.appendChild(noteStyleBtn);
 
         const resizeCalloutBtn = createButton('Redimensionar nota', '↔️', null, null, () => {
             const selection = window.getSelection();
@@ -3700,10 +3844,12 @@ document.addEventListener('DOMContentLoaded', function () {
         if (callout) {
             noteBgColorInput.value = rgbToHex(callout.style.backgroundColor || '#ffffff');
             noteBorderColorInput.value = rgbToHex(callout.style.borderColor || '#000000');
+            noteTextColorInput.value = rgbToHex(callout.style.color || '#000000');
             noteRadiusInput.value = parseInt(callout.style.borderRadius) || 8;
-            noteBorderWidthInput.value = parseInt(callout.style.borderWidth) || 2;
-            notePaddingInput.value = parseInt(callout.style.padding) || 8;
-            noteMarginInput.value = parseInt(callout.style.marginTop) || 8;
+            const bw = parseInt(callout.style.borderWidth);
+            noteBorderWidthInput.value = isNaN(bw) ? '' : bw;
+            notePaddingInput.value = parseInt(callout.style.padding) || 12;
+            noteMarginInput.value = parseInt(callout.style.marginTop) || 20;
             noteShadowInput.checked = callout.classList.contains('note-shadow');
         }
     }
@@ -3714,10 +3860,10 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     function applyNoteStyle(opts) {
-        const PREDEF_CLASSES = ['note-blue','note-green','note-yellow','note-red','note-purple','note-gray'];
+        const PREDEF_CLASSES = NOTE_PRESETS.map(p => p.class);
         if (!currentCallout) {
             const callout = document.createElement('div');
-            callout.className = 'note-callout';
+            callout.className = 'note-callout note-resizable';
             callout.setAttribute('role','note');
             callout.setAttribute('aria-label','Nota');
             if (savedEditorSelection && !savedEditorSelection.collapsed) {
@@ -3752,12 +3898,35 @@ document.addEventListener('DOMContentLoaded', function () {
         currentCallout.contentEditable = 'false';
         currentCallout.classList.remove(...PREDEF_CLASSES);
         if (opts.presetClass) currentCallout.classList.add(opts.presetClass);
+        currentCallout.classList.add('note-resizable');
         currentCallout.style.backgroundColor = opts.backgroundColor;
         currentCallout.style.borderColor = opts.borderColor;
-        currentCallout.style.borderWidth = opts.borderWidth + 'px';
+        if (typeof opts.borderWidth === 'number') {
+            currentCallout.style.borderWidth = opts.borderWidth + 'px';
+        } else {
+            currentCallout.style.removeProperty('border-width');
+        }
         currentCallout.style.borderRadius = opts.borderRadius + 'px';
         currentCallout.style.padding = opts.padding + 'px';
         currentCallout.style.margin = opts.margin + 'px 0';
+        if (opts.accentColor) {
+            currentCallout.style.setProperty('--accent-color', opts.accentColor);
+        } else {
+            currentCallout.style.removeProperty('--accent-color');
+        }
+        if (opts.gradientStart) {
+            currentCallout.style.setProperty('--gradient-start', opts.gradientStart);
+        } else {
+            currentCallout.style.removeProperty('--gradient-start');
+        }
+        if (opts.gradientEnd) {
+            currentCallout.style.setProperty('--gradient-end', opts.gradientEnd);
+        } else {
+            currentCallout.style.removeProperty('--gradient-end');
+        }
+        if (opts.textColor) {
+            currentCallout.style.color = opts.textColor;
+        }
         if (opts.shadow) {
             currentCallout.classList.add('note-shadow');
         } else {
@@ -5986,37 +6155,42 @@ document.addEventListener('DOMContentLoaded', function () {
         });
         applyNoteStyleBtn.addEventListener('click', (e) => {
             e.preventDefault();
+            const bw = noteBorderWidthInput.value !== '' ? parseInt(noteBorderWidthInput.value) : undefined;
             const opts = {
                 backgroundColor: noteBgColorInput.value,
                 borderColor: noteBorderColorInput.value,
+                textColor: noteTextColorInput.value,
                 borderRadius: parseInt(noteRadiusInput.value) || 0,
-                borderWidth: parseInt(noteBorderWidthInput.value) || 0,
+                borderWidth: bw,
                 padding: parseInt(notePaddingInput.value) || 0,
                 margin: parseInt(noteMarginInput.value) || 0,
-                shadow: noteShadowInput.checked
+                shadow: noteShadowInput.checked,
+                accentColor: noteBorderColorInput.value,
+                gradientStart: noteBorderColorInput.value,
+                gradientEnd: noteBorderColorInput.value
             };
             applyNoteStyle(opts);
         });
-        noteStyleModal.querySelectorAll('.predef-note-btn').forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                e.preventDefault();
-                const opts = {
-                    backgroundColor: btn.dataset.bg,
-                    borderColor: btn.dataset.border,
-                    borderRadius: 8,
-                    borderWidth: 2,
-                    padding: 8,
-                    margin: 8,
-                    shadow: false,
-                    presetClass: btn.classList.contains('note-blue') ? 'note-blue' :
-                                 btn.classList.contains('note-green') ? 'note-green' :
-                                 btn.classList.contains('note-yellow') ? 'note-yellow' :
-                                 btn.classList.contains('note-red') ? 'note-red' :
-                                 btn.classList.contains('note-purple') ? 'note-purple' :
-                                 btn.classList.contains('note-gray') ? 'note-gray' : null
-                };
-                applyNoteStyle(opts);
-            });
+        noteStylePre.addEventListener('click', (e) => {
+            const btn = e.target.closest('.predef-note-btn');
+            if (!btn) return;
+            e.preventDefault();
+            const bw = btn.dataset.borderWidth !== undefined ? parseInt(btn.dataset.borderWidth) : undefined;
+            const opts = {
+                backgroundColor: btn.dataset.bg,
+                borderColor: btn.dataset.border,
+                textColor: btn.dataset.text,
+                borderRadius: parseInt(btn.dataset.radius) || 8,
+                borderWidth: bw,
+                padding: parseInt(btn.dataset.padding) || 12,
+                margin: parseInt(btn.dataset.margin) || 20,
+                shadow: btn.dataset.shadow === 'true',
+                presetClass: btn.dataset.presetClass || null,
+                accentColor: btn.dataset.accent || null,
+                gradientStart: btn.dataset.gradientStart || null,
+                gradientEnd: btn.dataset.gradientEnd || null
+            };
+            applyNoteStyle(opts);
         });
 
         // --- Quick Note Modal Listeners ---


### PR DESCRIPTION
## Summary
- ensure preset borders remain intact and use highlight-style palettes for custom colors
- let table toolbars appear above selections to keep tables visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e52716dc832c85c8de5855073235