### PR TITLE
feat: add configurable note styles

### DIFF
--- a/index.css
+++ b/index.css
@@ -863,17 +863,21 @@ table.resizable-table.selected .table-resize-handle {
         }
 
 /* Note callout styles */
-.note-callout {
+.note-callout,
+.note {
     border-radius: 8px;
     border: 2px solid var(--border-color);
     padding: 8px;
     margin: 8px 0;
 }
-.note-callout-content {
+.note-callout-content,
+.note-content {
     outline: none;
 }
 .note-callout ul,
-.note-callout ol {
+.note-callout ol,
+.note-content ul,
+.note-content ol {
     margin: 0;
     padding-left: 1.25rem;
 }

--- a/index.html
+++ b/index.html
@@ -607,18 +607,12 @@
                 <button id="note-style-tab-custom" class="flex-1 p-1">Personalizado</button>
             </div>
             <div id="note-style-pre" class="space-y-2">
-                <div class="grid grid-cols-2 gap-2">
-                    <button class="predef-note-btn note-callout note-blue" data-bg="#dbeafe" data-border="#3b82f6">Azul</button>
-                    <button class="predef-note-btn note-callout note-green" data-bg="#d1fae5" data-border="#10b981">Verde</button>
-                    <button class="predef-note-btn note-callout note-yellow" data-bg="#fef9c3" data-border="#eab308">Amarillo</button>
-                    <button class="predef-note-btn note-callout note-red" data-bg="#fee2e2" data-border="#ef4444">Rojo</button>
-                    <button class="predef-note-btn note-callout note-purple" data-bg="#ede9fe" data-border="#8b5cf6">Morado</button>
-                    <button class="predef-note-btn note-callout note-gray" data-bg="#f3f4f6" data-border="#6b7280">Gris</button>
-                </div>
+                <div class="grid grid-cols-2 gap-2"></div>
             </div>
             <div id="note-style-custom" class="hidden space-y-2">
                 <label class="flex items-center justify-between">Fondo <input type="color" id="note-bg-color" value="#ffffff" class="border"></label>
                 <label class="flex items-center justify-between">Borde <input type="color" id="note-border-color" value="#000000" class="border"></label>
+                <label class="flex items-center justify-between">Texto <input type="color" id="note-text-color" value="#000000" class="border"></label>
                 <label class="flex items-center justify-between">Radio <input type="number" id="note-radius" value="8" class="w-16 border"></label>
                 <label class="flex items-center justify-between">Espesor <input type="number" id="note-border-width" value="2" class="w-16 border"></label>
                 <label class="flex items-center justify-between">Padding <input type="number" id="note-padding" value="8" class="w-16 border"></label>


### PR DESCRIPTION
## Summary
- add `noteStyles` config and dynamic menu for inserting notes
- enable manual color editing and resizing support for notes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7099b441c832ca83e329903632b58