### PR TITLE
feat: add configurable note styles with resizable notes

### DIFF
--- a/index.html
+++ b/index.html
@@ -607,18 +607,12 @@
                 <button id="note-style-tab-custom" class="flex-1 p-1">Personalizado</button>
             </div>
             <div id="note-style-pre" class="space-y-2">
-                <div class="grid grid-cols-2 gap-2">
-                    <button class="predef-note-btn note-callout note-blue" data-bg="#dbeafe" data-border="#3b82f6">Azul</button>
-                    <button class="predef-note-btn note-callout note-green" data-bg="#d1fae5" data-border="#10b981">Verde</button>
-                    <button class="predef-note-btn note-callout note-yellow" data-bg="#fef9c3" data-border="#eab308">Amarillo</button>
-                    <button class="predef-note-btn note-callout note-red" data-bg="#fee2e2" data-border="#ef4444">Rojo</button>
-                    <button class="predef-note-btn note-callout note-purple" data-bg="#ede9fe" data-border="#8b5cf6">Morado</button>
-                    <button class="predef-note-btn note-callout note-gray" data-bg="#f3f4f6" data-border="#6b7280">Gris</button>
-                </div>
+                <div id="note-styles-container" class="grid grid-cols-2 gap-2"></div>
             </div>
             <div id="note-style-custom" class="hidden space-y-2">
                 <label class="flex items-center justify-between">Fondo <input type="color" id="note-bg-color" value="#ffffff" class="border"></label>
                 <label class="flex items-center justify-between">Borde <input type="color" id="note-border-color" value="#000000" class="border"></label>
+                <label class="flex items-center justify-between">Texto <input type="color" id="note-text-color" value="#000000" class="border"></label>
                 <label class="flex items-center justify-between">Radio <input type="number" id="note-radius" value="8" class="w-16 border"></label>
                 <label class="flex items-center justify-between">Espesor <input type="number" id="note-border-width" value="2" class="w-16 border"></label>
                 <label class="flex items-center justify-between">Padding <input type="number" id="note-padding" value="8" class="w-16 border"></label>


### PR DESCRIPTION
## Summary
- add dynamic note style menu built from configurable `noteStyles` array
- allow custom background, border, and text colors
- make inserted notes resizable and reopen style menu on click

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7099b441c832ca83e329903632b58