### PR TITLE
Refine editor toolbar and table menu

### DIFF
--- a/image-tools.js
+++ b/image-tools.js
@@ -1,29 +1,11 @@
 /**
  * Utilities for advanced image handling within the notes editor.
- * Provides insertion (button, drag&drop, paste), resizing via handles
+ * Supports insertion via drag&drop and paste, resizing via handles
  * with aspect ratio preservation, layout modes and a floating control panel.
  */
 export function setupImageTools(editor, toolbar) {
   // --- Insertion helpers --------------------------------------------------
-  const fileInput = document.createElement('input');
-  fileInput.type = 'file';
-  fileInput.accept = 'image/*';
-  fileInput.multiple = true;
-  fileInput.className = 'hidden';
-  toolbar.appendChild(fileInput);
-
-  const insertBtn = document.createElement('button');
-  insertBtn.className = 'toolbar-btn';
-  insertBtn.title = 'Insertar imagen';
-  insertBtn.textContent = '🖼️';
-  insertBtn.addEventListener('click', () => fileInput.click());
-  toolbar.appendChild(insertBtn);
-
-  fileInput.addEventListener('change', e => {
-    const files = Array.from(e.target.files || []);
-    if (files.length) insertFiles(files);
-    fileInput.value = '';
-  });
+  // Removed toolbar button and file input for manual image insertion.
 
   editor.addEventListener('dragover', e => {
     if (Array.from(e.dataTransfer.items || []).some(i => i.type.startsWith('image/'))) {


### PR DESCRIPTION
## Summary
- Remove note and image insertion buttons from editor toolbar
- Add Calibri font option and proportional font size controls
- Position table options menu above tables for unobstructed view

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c715029d70832c9d8ca439d0cb636e