### PR TITLE
Improve note box styling and resizing

### DIFF
--- a/index.css
+++ b/index.css
@@ -959,10 +959,11 @@ table.resizable-table.selected .table-resize-handle {
 .table-theme-teal th { background:#e0f2f1; color:#004d40; }
 .table-theme-teal td { background:#ffffff; }
 .note-resizable {
-    resize: horizontal;
+    resize: both;
     overflow: auto;
     display: inline-block;
     max-width: 100%;
+    position: relative;
 }
 .note-blue-left { border:1px solid #b3e5fc; border-left-width:6px; background:#f7fcff; }
 .note-green-card { border:1px solid #c8e6c9; background:#fbfffb; }

--- a/index.html
+++ b/index.html
@@ -623,8 +623,11 @@
             </div>
             <div id="note-style-custom" class="hidden space-y-2">
                 <label class="flex items-center justify-between">Fondo <input type="color" id="note-bg-color" value="#ffffff" class="border"></label>
+                <div id="note-bg-palette"></div>
                 <label class="flex items-center justify-between">Borde <input type="color" id="note-border-color" value="#000000" class="border"></label>
+                <div id="note-border-palette"></div>
                 <label class="flex items-center justify-between">Texto <input type="color" id="note-text-color" value="#000000" class="border"></label>
+                <div id="note-text-palette"></div>
                 <label class="flex items-center justify-between">Radio <input type="number" id="note-radius" value="8" class="w-16 border"></label>
                 <label class="flex items-center justify-between">Espesor <input type="number" id="note-border-width" value="2" class="w-16 border"></label>
                 <label class="flex items-center justify-between">Padding <input type="number" id="note-padding" value="8" class="w-16 border"></label>


### PR DESCRIPTION
## Summary
- Preserve scroll position after changing note style to avoid jumping to top.
- Allow styled note boxes to be resized from both bottom corners.
- Add color palettes matching the text editor to customize note colors.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c73ec1d640832c9cc78d77bbc30519