### PR TITLE
Add resizing handles and color palettes for callout boxes

### DIFF
--- a/index.css
+++ b/index.css
@@ -897,6 +897,21 @@ table.resizable-table.selected .table-resize-handle {
 .note-resize-handle.br { right: -6px; cursor: nwse-resize; }
 .note-resize-handle.bl { left: -6px; cursor: nesw-resize; }
 
+.note-callout-tools {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    display: flex;
+    gap: 4px;
+}
+
+.note-callout-btn {
+    min-width: 20px;
+    min-height: 20px;
+    padding: 0;
+    font-size: 12px;
+}
+
 .note-color-palette {
     display: flex;
     flex-wrap: wrap;

--- a/index.css
+++ b/index.css
@@ -873,6 +873,7 @@ table.resizable-table.selected .table-resize-handle {
     background: #fff;
     border-radius: 8px;
     border: 1px solid transparent;
+    position: relative;
 }
 .note-callout h4{margin:0 0 6px 0; font-size:14px}
 .note-callout .muted{opacity:.85}
@@ -883,6 +884,24 @@ table.resizable-table.selected .table-resize-handle {
 .note-callout ol {
     margin: 0;
     padding-left: 1.25rem;
+}
+
+.note-resize-handle {
+    position: absolute;
+    width: 12px;
+    height: 12px;
+    background: var(--border-color, #ccc);
+    border-radius: 50%;
+    bottom: -6px;
+}
+.note-resize-handle.br { right: -6px; cursor: nwse-resize; }
+.note-resize-handle.bl { left: -6px; cursor: nesw-resize; }
+
+.note-color-palette {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-top: 4px;
 }
 
 /* Indentation levels applied via classes instead of inline spaces */

--- a/index.js
+++ b/index.js
@@ -669,6 +669,33 @@ document.addEventListener('DOMContentLoaded', function () {
         callout.appendChild(br);
         callout.appendChild(bl);
 
+        const tools = document.createElement('div');
+        tools.className = 'note-callout-tools';
+        const copyBtn = document.createElement('button');
+        copyBtn.className = 'note-callout-btn toolbar-btn copy';
+        copyBtn.title = 'Copiar HTML';
+        copyBtn.textContent = '📋';
+        copyBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            navigator.clipboard?.writeText(callout.outerHTML || '');
+        });
+        const delBtn = document.createElement('button');
+        delBtn.className = 'note-callout-btn toolbar-btn delete';
+        delBtn.title = 'Eliminar nota';
+        delBtn.textContent = '🗑';
+        delBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            callout.remove();
+            if (activeResizableCallout === callout) {
+                activeResizableCallout = null;
+            }
+        });
+        tools.appendChild(copyBtn);
+        tools.appendChild(delBtn);
+        callout.appendChild(tools);
+
         const start = (e, corner) => {
             e.preventDefault();
             const startX = e.clientX;
@@ -702,6 +729,7 @@ document.addEventListener('DOMContentLoaded', function () {
     function removeCalloutResizeHandles(callout) {
         if (!callout) return;
         callout.querySelectorAll('.note-resize-handle').forEach(h => h.remove());
+        callout.querySelectorAll('.note-callout-tools').forEach(t => t.remove());
     }
 
     /*
@@ -722,11 +750,15 @@ document.addEventListener('DOMContentLoaded', function () {
         const withSubnoteSelection = (fn) => {
             const sel = window.getSelection();
             const range = sel && sel.rangeCount > 0 ? sel.getRangeAt(0).cloneRange() : null;
+            const scrollY = window.scrollY;
+            const modalScroll = notesModalContent.scrollTop;
             fn();
             if (range) {
                 sel.removeAllRanges();
                 sel.addRange(range);
             }
+            window.scrollTo(0, scrollY);
+            notesModalContent.scrollTop = modalScroll;
         };
 
         // Helper to create a toolbar button for sub-note editor

--- a/index.js
+++ b/index.js
@@ -627,6 +627,82 @@ document.addEventListener('DOMContentLoaded', function () {
     const applyNoteStyleBtn = getElem('apply-note-style-btn');
     const cancelNoteStyleBtn = getElem('cancel-note-style-btn');
 
+    let savedNoteScrollY = 0;
+
+    function createNoteColorPalette(input, colors) {
+        const palette = document.createElement('div');
+        palette.className = 'note-color-palette';
+        colors.forEach(color => {
+            const swatch = document.createElement('button');
+            swatch.className = 'color-swatch';
+            if (color === 'transparent') {
+                swatch.style.backgroundImage = 'linear-gradient(to top left, transparent calc(50% - 1px), red, transparent calc(50% + 1px))';
+                swatch.style.backgroundColor = 'var(--bg-secondary)';
+            } else {
+                swatch.style.backgroundColor = color;
+            }
+            swatch.addEventListener('click', (e) => {
+                e.preventDefault();
+                input.value = color;
+            });
+            palette.appendChild(swatch);
+        });
+        input.insertAdjacentElement('afterend', palette);
+    }
+
+    const paletteTextColors = ['#000000', '#FF0000', '#0000FF', '#008000', '#FFA500', '#FFFF00', '#800080', '#FFC0CB', '#00FFFF', '#00008B', '#8B0000', '#FF8C00', '#FFD700', '#ADFF2F', '#4B0082', '#48D1CC', '#191970', '#A52A2A', '#F0E68C', '#ADD8E6', '#DDA0DD', '#90EE90', '#FA8072'];
+    const paletteBgColors = ['#FAFAD2', 'transparent', '#FFFFFF', '#FFFF00', '#ADD8E6', '#F0FFF0', '#FFF0F5', '#F5FFFA', '#F0F8FF', '#E6E6FA', '#FFF5EE', '#FAEBD7', '#FFE4E1', '#FFFFE0', '#D3FFD3', '#B0E0E6', '#FFB6C1', '#F5DEB3', '#C8A2C8', '#FFDEAD', '#E0FFFF', '#FDF5E6', '#FFFACD', '#F8F8FF', '#D3D3D3', '#A9A9A9', '#696969', '#C4A484', '#A0522D', '#8B4513'];
+
+    createNoteColorPalette(noteBgColorInput, paletteBgColors);
+    createNoteColorPalette(noteBorderColorInput, paletteBgColors);
+    createNoteColorPalette(noteTextColorInput, paletteTextColors);
+
+    let activeResizableCallout = null;
+
+    function addCalloutResizeHandles(callout) {
+        removeCalloutResizeHandles(callout);
+        const br = document.createElement('div');
+        br.className = 'note-resize-handle br';
+        const bl = document.createElement('div');
+        bl.className = 'note-resize-handle bl';
+        callout.appendChild(br);
+        callout.appendChild(bl);
+
+        const start = (e, corner) => {
+            e.preventDefault();
+            const startX = e.clientX;
+            const startY = e.clientY;
+            const startWidth = callout.offsetWidth;
+            const startHeight = callout.offsetHeight;
+            const startMargin = parseFloat(getComputedStyle(callout).marginLeft) || 0;
+            function onMove(evt) {
+                const dx = evt.clientX - startX;
+                const dy = evt.clientY - startY;
+                if (corner === 'br') {
+                    callout.style.width = startWidth + dx + 'px';
+                } else {
+                    callout.style.width = Math.max(30, startWidth - dx) + 'px';
+                    callout.style.marginLeft = startMargin + dx + 'px';
+                }
+                callout.style.height = startHeight + dy + 'px';
+            }
+            function onUp() {
+                document.removeEventListener('mousemove', onMove);
+                document.removeEventListener('mouseup', onUp);
+            }
+            document.addEventListener('mousemove', onMove);
+            document.addEventListener('mouseup', onUp);
+        };
+
+        br.addEventListener('mousedown', e => start(e, 'br'));
+        bl.addEventListener('mousedown', e => start(e, 'bl'));
+    }
+
+    function removeCalloutResizeHandles(callout) {
+        if (!callout) return;
+        callout.querySelectorAll('.note-resize-handle').forEach(h => h.remove());
+    }
+
     /*
      * Build the simplified toolbar for sub-note editing.  This toolbar intentionally omits
      * certain controls available in the main note editor, such as line height, image
@@ -3667,6 +3743,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     function openNoteStyleModal(callout = null) {
+        savedNoteScrollY = window.scrollY;
         currentCallout = callout;
         noteStyleModal.classList.add('visible');
         noteStyleTabPre.classList.add('border-b-2', 'border-blue-500');
@@ -3688,6 +3765,7 @@ document.addEventListener('DOMContentLoaded', function () {
     function closeNoteStyleModal() {
         noteStyleModal.classList.remove('visible');
         currentCallout = null;
+        window.scrollTo(0, savedNoteScrollY);
     }
 
     function applyNoteStyle(opts) {
@@ -5768,17 +5846,29 @@ document.addEventListener('DOMContentLoaded', function () {
              }
 
              // Handle gallery link clicks
-             const galleryLink = e.target.closest('.gallery-link');
-             if (galleryLink) {
-                 e.preventDefault();
-                 // Persist the link so that caption edits and image updates can be saved back
-                 activeGalleryLinkForLightbox = galleryLink;
-                 openImageLightbox(galleryLink.dataset.images);
-                 return;
-             }
+            const galleryLink = e.target.closest('.gallery-link');
+            if (galleryLink) {
+                e.preventDefault();
+                // Persist the link so that caption edits and image updates can be saved back
+                activeGalleryLinkForLightbox = galleryLink;
+                openImageLightbox(galleryLink.dataset.images);
+                return;
+            }
 
-             // Handle inline note icon clicks
-             const inlineIcon = e.target.closest('.inline-note');
+            const callout = e.target.closest('.note-callout');
+            if (callout) {
+                if (activeResizableCallout !== callout) {
+                    removeCalloutResizeHandles(activeResizableCallout);
+                    addCalloutResizeHandles(callout);
+                    activeResizableCallout = callout;
+                }
+            } else {
+                removeCalloutResizeHandles(activeResizableCallout);
+                activeResizableCallout = null;
+            }
+
+            // Handle inline note icon clicks
+            const inlineIcon = e.target.closest('.inline-note');
              if (inlineIcon) {
                  e.preventDefault();
                  hideInlineNoteTooltip(inlineIcon);

--- a/index.js
+++ b/index.js
@@ -628,6 +628,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const cancelNoteStyleBtn = getElem('cancel-note-style-btn');
 
     let savedNoteScrollY = 0;
+    let savedNoteScrollTop = 0;
 
     function createNoteColorPalette(input, colors) {
         const palette = document.createElement('div');
@@ -2206,11 +2207,15 @@ document.addEventListener('DOMContentLoaded', function () {
         const withEditorSelection = (fn) => {
             const sel = window.getSelection();
             const range = sel && sel.rangeCount > 0 ? sel.getRangeAt(0).cloneRange() : null;
+            const scrollY = window.scrollY;
+            const modalScroll = notesModalContent.scrollTop;
             fn();
             if (range) {
                 sel.removeAllRanges();
                 sel.addRange(range);
             }
+            window.scrollTo(0, scrollY);
+            notesModalContent.scrollTop = modalScroll;
         };
 
         const createButton = (title, content, command, value = null, action = null, extraClass = '') => {
@@ -3744,6 +3749,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     function openNoteStyleModal(callout = null) {
         savedNoteScrollY = window.scrollY;
+        savedNoteScrollTop = notesModalContent.scrollTop;
         currentCallout = callout;
         noteStyleModal.classList.add('visible');
         noteStyleTabPre.classList.add('border-b-2', 'border-blue-500');
@@ -3766,6 +3772,7 @@ document.addEventListener('DOMContentLoaded', function () {
         noteStyleModal.classList.remove('visible');
         currentCallout = null;
         window.scrollTo(0, savedNoteScrollY);
+        notesModalContent.scrollTop = savedNoteScrollTop;
     }
 
     function applyNoteStyle(opts) {

--- a/index.js
+++ b/index.js
@@ -756,9 +756,13 @@ document.addEventListener('DOMContentLoaded', function () {
             if (range) {
                 sel.removeAllRanges();
                 sel.addRange(range);
+                const active = document.activeElement;
+                active?.focus?.({ preventScroll: true });
             }
-            window.scrollTo(0, scrollY);
-            notesModalContent.scrollTop = modalScroll;
+            requestAnimationFrame(() => {
+                window.scrollTo(0, scrollY);
+                notesModalContent.scrollTop = modalScroll;
+            });
         };
 
         // Helper to create a toolbar button for sub-note editor
@@ -3803,8 +3807,10 @@ document.addEventListener('DOMContentLoaded', function () {
     function closeNoteStyleModal() {
         noteStyleModal.classList.remove('visible');
         currentCallout = null;
-        window.scrollTo(0, savedNoteScrollY);
-        notesModalContent.scrollTop = savedNoteScrollTop;
+        requestAnimationFrame(() => {
+            window.scrollTo(0, savedNoteScrollY);
+            notesModalContent.scrollTop = savedNoteScrollTop;
+        });
     }
 
     function applyNoteStyle(opts) {
@@ -3866,8 +3872,8 @@ document.addEventListener('DOMContentLoaded', function () {
         const selection = window.getSelection();
         selection.removeAllRanges();
         selection.addRange(range);
-        inner.focus();
-        notesEditor.focus();
+        inner.focus({ preventScroll: true });
+        notesEditor.focus({ preventScroll: true });
         closeNoteStyleModal();
     }
 


### PR DESCRIPTION
## Summary
- Preserve scroll position when editing callout styles
- Add corner resize handles for note callouts
- Share editor color palettes in callout style modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c73ec1d640832c9cc78d77bbc30519