### PR TITLE
Improve callout styling and editor tools

### DIFF
--- a/index.css
+++ b/index.css
@@ -865,9 +865,9 @@ table.resizable-table.selected .table-resize-handle {
 
 /* Note callout styles */
 .note-callout {
-    font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
-    font-size: 13px;
-    line-height: 1.1;
+    font-family: inherit;
+    font-size: inherit;
+    line-height: inherit;
     padding: 10px 12px;
     margin: 20px 0;
     background: #fff;


### PR DESCRIPTION
## Summary
- Preserve user formatting when applying box feature and prevent scroll jumps
- Add delete-line toolbar button
- Add rich copy button for callout boxes
- Remove lingering note tabs and reset undo history when closing notes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c769bcc0f0832c876d4a5c7c414837