### PR TITLE
Enable resizing and moving of clinical note cards

### DIFF
--- a/index.css
+++ b/index.css
@@ -172,7 +172,8 @@
         #notes-editor:focus { outline: none; }
         #notes-editor img { max-width: 100%; height: auto; border-radius: 0.5rem; cursor: pointer; }
         #notes-editor img.selected-for-resize { outline: 2px solid var(--btn-primary-bg); }
-        #notes-editor table.selected-for-move { outline: 2px solid var(--btn-primary-bg); }
+        #notes-editor table.selected-for-move,
+        #notes-editor .resizable-block.selected-for-move { outline: 2px solid var(--btn-primary-bg); }
 
         /* Display multiple images in a row */
         #notes-editor .image-row {
@@ -389,8 +390,9 @@
             padding: 3px;
         }
 
-/* Basic styles for resizable tables */
-table.resizable-table {
+/* Basic styles for resizable tables and custom blocks */
+table.resizable-table,
+.resizable-block {
     position: relative;
 }
 table.resizable-table td,
@@ -398,7 +400,7 @@ table.resizable-table th {
     position: relative;
 }
 
-table.resizable-table .table-resize-handle {
+:is(table.resizable-table, .resizable-block) .table-resize-handle {
     position: absolute;
     width: 8px;
     height: 8px;
@@ -412,9 +414,21 @@ table.resizable-table .table-resize-handle {
     box-sizing: border-box;
     display: none;
 }
-
-table.resizable-table.selected .table-resize-handle {
+:is(table.resizable-table, .resizable-block).selected .table-resize-handle {
     display: block;
+}
+
+.nota-clinica {
+    display: block;
+    max-width: 100%;
+    box-sizing: border-box;
+}
+
+.nota-clinica > .nota-clinica__header,
+.nota-clinica > .nota-clinica__body {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
 }
 
 /* Floating image styles */

--- a/table-resize.js
+++ b/table-resize.js
@@ -6,6 +6,7 @@ export function makeTableResizable(table, { minSize = 30 } = {}) {
   let startSize = 0;
   let startWidth = 0;
   let startHeight = 0;
+  const isTableElement = table instanceof HTMLTableElement;
 
   table.style.position = 'relative';
   const handle = document.createElement('div');
@@ -32,7 +33,7 @@ export function makeTableResizable(table, { minSize = 30 } = {}) {
   document.addEventListener('keydown', cancelOnEsc);
 
   function onHover(e) {
-    if (activeResize) return;
+    if (!isTableElement || activeResize) return;
     const rect = table.getBoundingClientRect();
     const x = e.clientX - rect.left;
     const y = e.clientY - rect.top;
@@ -54,7 +55,7 @@ export function makeTableResizable(table, { minSize = 30 } = {}) {
   }
 
   function startResize(e) {
-    if (!hoverEdge) return;
+    if (!isTableElement || !hoverEdge) return;
     e.preventDefault();
     activeResize = hoverEdge;
     startX = e.clientX;
@@ -119,6 +120,7 @@ export function makeTableResizable(table, { minSize = 30 } = {}) {
   }
 
   function findColEdge(x) {
+    if (!isTableElement) return -1;
     let left = 0;
     const row = table.rows[0];
     if (!row) return -1;
@@ -130,6 +132,7 @@ export function makeTableResizable(table, { minSize = 30 } = {}) {
   }
 
   function findRowEdge(y) {
+    if (!isTableElement) return -1;
     let top = 0;
     for (let i = 0; i < table.rows.length; i++) {
       top += table.rows[i].offsetHeight;
@@ -139,11 +142,13 @@ export function makeTableResizable(table, { minSize = 30 } = {}) {
   }
 
   function getColWidth(index) {
+    if (!isTableElement) return 0;
     const cell = table.rows[0]?.cells[index];
     return cell ? cell.offsetWidth : 0;
   }
 
   function setColWidth(index, width) {
+    if (!isTableElement) return;
     for (const row of table.rows) {
       const cell = row.cells[index];
       if (cell) cell.style.width = width + 'px';
@@ -151,16 +156,19 @@ export function makeTableResizable(table, { minSize = 30 } = {}) {
   }
 
   function getRowHeight(index) {
+    if (!isTableElement) return 0;
     const row = table.rows[index];
     return row ? row.offsetHeight : 0;
   }
 
   function setRowHeight(index, height) {
+    if (!isTableElement) return;
     const row = table.rows[index];
     if (row) row.style.height = height + 'px';
   }
 
   function getEdgePosition(type, index) {
+    if (!isTableElement) return 0;
     if (type === 'col') {
       let left = 0;
       const row = table.rows[0];


### PR DESCRIPTION
## Summary
- wrap clinical note header/body pairs in a container so they behave as a single block
- extend the resizer utility and styles so non-table blocks reuse the resizing handle
- hook the notes editor so these clinical note cards respond to move and resize actions just like tables

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9fca6f614832cb8f26692c1c7daa9