### PR TITLE
Restore tooltip editing tool

### DIFF
--- a/index.css
+++ b/index.css
@@ -283,6 +283,69 @@
     resize: both;
     overflow: auto;
 }
+
+/* Tooltip inline para notas breves */
+.tooltip-wrapper {
+    position: relative;
+    cursor: help;
+    border-bottom: 1px dotted currentColor;
+}
+
+.tooltip-wrapper:focus {
+    outline: none;
+}
+
+.tooltip-wrapper:focus-visible {
+    outline: 2px solid var(--btn-primary-bg, #2563eb);
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
+.tooltip-wrapper::before,
+.tooltip-wrapper::after {
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.tooltip-wrapper::before {
+    content: '';
+    position: absolute;
+    left: 50%;
+    bottom: 100%;
+    transform: translate(-50%, -2px);
+    border-width: 6px;
+    border-style: solid;
+    border-color: transparent transparent var(--bg-secondary) transparent;
+    z-index: 1501;
+}
+
+.tooltip-wrapper::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    left: 50%;
+    bottom: calc(100% + 8px);
+    transform: translate(-50%, 4px);
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 0.375rem;
+    padding: 0.35rem 0.5rem;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    max-width: min(320px, calc(100vw - 32px));
+    width: max-content;
+    min-width: 160px;
+    white-space: normal;
+    z-index: 1500;
+}
+
+.tooltip-wrapper:hover::before,
+.tooltip-wrapper:hover::after,
+.tooltip-wrapper:focus::before,
+.tooltip-wrapper:focus::after {
+    opacity: 1;
+    transform: translate(-50%, 0);
+}
         /* Toolbar styles */
         .toolbar-separator {
             border-left: 1px solid var(--border-color);


### PR DESCRIPTION
## Summary
- reintroduce tooltip editing with dedicated helpers and a toolbar action that prompts for tooltip text and preserves history
- allow editing or removal of tooltips via double-click with improved selection handling
- style inline tooltip wrappers so hover and focus reveal the stored note content

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca2231a370832c81cb1f46540ab2c0