### PR TITLE
Improve tooltip toolbar behavior

### DIFF
--- a/index.css
+++ b/index.css
@@ -440,6 +440,19 @@
     font-size: 0.65rem;
     color: var(--text-secondary, #6b7280);
 }
+
+.toolbar-btn.tooltip-icon-insert-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 26px;
+    padding: 2px 4px;
+}
+
+.toolbar-btn.tooltip-icon-insert-btn sup {
+    font-size: 1rem;
+    line-height: 1;
+}
         /* Toolbar styles */
         .toolbar-separator {
             border-left: 1px solid var(--border-color);

--- a/index.js
+++ b/index.js
@@ -623,6 +623,7 @@ document.addEventListener('DOMContentLoaded', function () {
     let tooltipIconSelector = null;
     let tooltipIconButtons = [];
     let tooltipIconPickerBtn = null;
+    let tooltipInsertBtn = null;
     let tooltipIconOutsideHandler = null;
     let hideTooltipIconSelector = () => {};
     let normalizeTooltipElement = () => {};
@@ -2344,6 +2345,15 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         };
 
+        const updateTooltipInsertButtonIcon = (icon) => {
+            if (!tooltipInsertBtn) return;
+            const sanitized = sanitizeTooltipIcon(icon);
+            tooltipInsertBtn.dataset.icon = sanitized;
+            tooltipInsertBtn.innerHTML = `<sup aria-hidden="true">${sanitized}</sup>`;
+            tooltipInsertBtn.setAttribute('aria-label', `Añadir tooltip (${sanitized})`);
+            tooltipInsertBtn.title = `Añadir tooltip (${sanitized})`;
+        };
+
         const highlightTooltipIcon = (icon) => {
             const sanitized = sanitizeTooltipIcon(icon);
             tooltipIconButtons.forEach(btn => {
@@ -2352,6 +2362,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
             });
             updateTooltipIconPickerLabel(sanitized);
+            updateTooltipInsertButtonIcon(sanitized);
             return sanitized;
         };
 
@@ -3722,7 +3733,10 @@ document.addEventListener('DOMContentLoaded', function () {
         updateTooltipIconPickerLabel(toolbarSelectedTooltipIcon);
         editorToolbar.appendChild(tooltipIconPickerBtn);
 
-        editorToolbar.appendChild(createButton('Añadir tooltip', '💬', null, null, handleTooltipTool));
+        tooltipInsertBtn = createButton('Añadir tooltip', '', null, null, handleTooltipTool, 'tooltip-icon-insert-btn');
+        tooltipInsertBtn.setAttribute('aria-label', 'Añadir tooltip');
+        editorToolbar.appendChild(tooltipInsertBtn);
+        updateTooltipInsertButtonIcon(toolbarSelectedTooltipIcon);
 
         editorToolbar.appendChild(createSeparator());
 


### PR DESCRIPTION
## Summary
- synchronize the tooltip insert control with the selected icon and update accessibility labels
- render the insert button with the current superscript icon so it matches the tooltip marker in the editor
- add dedicated styling for the tooltip insert button

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb4a584cb8832c93054c1dca958654