### PR TITLE
Enhance table styling tools and section navigation

### DIFF
--- a/index.css
+++ b/index.css
@@ -133,12 +133,13 @@
             padding: 1rem;
         }
         
-        .note-icon, .link-anchor, .edit-link-icon, .print-section-btn { display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: 50%; transition: background-color 0.2s, color 0.2s, opacity 0.2s, filter 0.2s; cursor: pointer; }
-        .note-icon:hover, .link-anchor:hover, .edit-link-icon:hover, .print-section-btn:hover { background-color: rgba(0,0,0,0.1); }
+        .note-icon, .link-anchor, .edit-link-icon, .print-section-btn, .save-section-html-btn { display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: 50%; transition: background-color 0.2s, color 0.2s, opacity 0.2s, filter 0.2s; cursor: pointer; }
+        .note-icon:hover, .link-anchor:hover, .edit-link-icon:hover, .print-section-btn:hover, .save-section-html-btn:hover { background-color: rgba(0,0,0,0.1); }
         
         .link-icon { width: 1.1em; height: 1.1em; }
         .note-icon svg, .print-section-btn { width: 1.1em; height: 1.1em; }
-        .note-icon.section-note-icon, .print-section-btn { color: var(--section-header-text); opacity: 0.8; }
+        .note-icon.section-note-icon, .print-section-btn, .save-section-html-btn { color: var(--section-header-text); opacity: 0.8; }
+        .save-section-html-btn { font-size: 0.85rem; font-weight: 700; }
         
         .note-icon.has-note {
             background-color: var(--btn-primary-bg);
@@ -1250,7 +1251,8 @@ table.resizable-table th {
     box-shadow: 0 18px 36px rgba(15, 23, 42, 0.2);
     display: none;
     z-index: 10000;
-    }
+    max-width: 720px;
+}
 .preset-style-popup .toolbar-btn {
     display: block;
     width: 100%;
@@ -1261,7 +1263,8 @@ table.resizable-table th {
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
-    min-width: 320px;
+    width: 100%;
+    min-width: 0;
 }
 .table-menu-tabs {
     display: flex;
@@ -1276,6 +1279,47 @@ table.resizable-table th {
     background: var(--bg-tertiary);
     font-weight: bold;
 }
+.table-edit-layout {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    width: 100%;
+}
+.table-edit-group {
+    flex: 1 1 200px;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-radius: 0.75rem;
+    padding: 0.55rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+.table-edit-group-title {
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-secondary);
+}
+.table-edit-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    justify-content: flex-start;
+    width: 100%;
+    border-radius: 0.65rem;
+    padding: 0.35rem 0.5rem;
+    background: transparent;
+}
+.table-edit-btn:hover,
+.table-edit-btn:focus-visible {
+    background: var(--bg-secondary);
+    box-shadow: inset 0 0 0 1px var(--border-color);
+}
+.table-edit-icon {
+    font-size: 0.95rem;
+}
 .line-style-group {
     display: flex;
     flex-wrap: wrap;
@@ -1288,6 +1332,25 @@ table.resizable-table th {
     gap: 0.5rem;
 }
 
+.table-style-layout {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    width: 100%;
+}
+
+.table-style-column {
+    flex: 1 1 250px;
+    min-width: 220px;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.table-spacing-column {
+    max-width: 320px;
+}
+
 .table-style-section-title {
     font-size: 0.8rem;
     font-weight: 600;
@@ -1298,14 +1361,14 @@ table.resizable-table th {
 
 .table-theme-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-    gap: 0.65rem;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.5rem;
 }
 
 .table-theme-option {
     border: 1px solid transparent;
     border-radius: 0.75rem;
-    padding: 0.5rem;
+    padding: 0.45rem;
     background: none;
     cursor: pointer;
     display: flex;
@@ -1330,6 +1393,7 @@ table.resizable-table th {
     border-radius: 0.6rem;
     overflow: hidden;
     box-shadow: inset 0 0 0 1px rgba(255,255,255,0.3);
+    min-height: 72px;
 }
 
 .table-theme-preview .header-row {
@@ -1357,7 +1421,7 @@ table.resizable-table th {
 }
 
 .table-theme-preview .body-row .cell {
-    height: 12px;
+    height: 10px;
     border-right: 1px solid var(--table-preview-border, var(--border-color));
     border-bottom: 1px solid var(--table-preview-border, var(--border-color));
 }
@@ -1379,10 +1443,54 @@ table.resizable-table th {
 }
 
 .table-theme-option-label {
-    font-size: 0.78rem;
+    font-size: 0.72rem;
     color: var(--text-secondary, #4b5563);
     display: block;
     text-align: center;
+}
+
+.table-spacing-control {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.table-spacing-label {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+}
+
+.table-spacing-value {
+    font-variant-numeric: tabular-nums;
+}
+
+.table-spacing-control input[type="range"] {
+    width: 100%;
+    accent-color: var(--accent-color, var(--btn-primary-bg, #2563eb));
+}
+
+.table-spacing-presets {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+}
+
+.table-spacing-btn {
+    flex: 1 1 140px;
+    border-radius: 0.65rem;
+    padding: 0.35rem 0.5rem;
+    font-size: 0.75rem;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+}
+
+.table-spacing-btn:hover,
+.table-spacing-btn:focus-visible {
+    background: var(--bg-secondary);
 }
 
 .table-header-list {
@@ -1738,4 +1846,130 @@ table.resizable-table th {
   padding: 2px 4px;
   margin-top: 4px;
   display: block;
+}
+.section-nav-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.35rem 0.6rem;
+    border-radius: 999px;
+    border: 1px solid var(--border-color);
+    background: var(--bg-tertiary);
+    color: inherit;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.section-nav-toggle.open {
+    background: var(--accent-color, var(--btn-primary-bg));
+    color: #fff;
+    border-color: transparent;
+}
+
+.section-nav-panel {
+    position: fixed;
+    top: 120px;
+    right: 16px;
+    width: min(320px, 90vw);
+    max-height: calc(100vh - 160px);
+    overflow-y: auto;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
+    transform: translateX(110%);
+    transition: transform 0.3s ease;
+    z-index: 9999;
+}
+
+.section-nav-panel.open {
+    transform: translateX(0);
+}
+
+.section-nav-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--border-color);
+    font-weight: 600;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+}
+
+.section-nav-close {
+    background: none;
+    border: none;
+    font-size: 1rem;
+    cursor: pointer;
+    color: inherit;
+    padding: 0.1rem 0.25rem;
+}
+
+.section-nav-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding: 0.75rem;
+}
+
+.section-nav-item {
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-start;
+    padding: 0.45rem 0.6rem;
+    border-radius: 0.6rem;
+    border: 1px solid transparent;
+    background: var(--bg-tertiary);
+    cursor: pointer;
+    font-size: 0.85rem;
+    color: var(--text-primary);
+    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.section-nav-item:hover,
+.section-nav-item:focus-visible {
+    border-color: var(--accent-color, var(--btn-primary-bg));
+}
+
+.section-nav-item.active {
+    background: var(--accent-color, var(--btn-primary-bg));
+    color: #fff;
+    border-color: transparent;
+}
+
+.section-export-body {
+    background: #f3f4f6;
+    color: #111827;
+    font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+    padding: 2.5rem;
+}
+
+.section-export-container {
+    max-width: 960px;
+    margin: 0 auto;
+    background: #ffffff;
+    border-radius: 16px;
+    padding: 2rem;
+    box-shadow: 0 24px 64px rgba(15, 23, 42, 0.18);
+}
+
+.section-export-title {
+    font-size: 1.6rem;
+    font-weight: 700;
+    margin-bottom: 1.5rem;
+    text-align: center;
+    color: #1f2937;
+}
+
+.section-export-container table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.section-export-container th,
+.section-export-container td {
+    border: 1px solid rgba(148, 163, 184, 0.6);
+    padding: 0.5rem 0.6rem;
+    text-align: left;
 }


### PR DESCRIPTION
## Summary
- reuse the preset style selector when editing colored text so the popup matches the styling panel
- add export-to-HTML controls per section and introduce a collapsible section navigation panel with active tracking
- redesign the table editor popup with grouped actions, theme previews, spacing controls, and column selection while constraining its size to the editor
- restore divider insertion so horizontal rules render without unwanted gaps

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc654536c0832c8c39c2e2dee9155a