### PR TITLE
Add help modal for toolbar buttons and windows

### DIFF
--- a/index.css
+++ b/index.css
@@ -104,7 +104,74 @@
         
         .modal-content { background: var(--modal-bg); color: var(--modal-text); padding: 1.5rem; border-radius: 0.5rem; width: 95%; box-shadow: 0 5px 15px rgba(0,0,0,0.3); transform: translateY(-20px); transition: transform 0.3s ease; display: flex; flex-direction: column; }
         .modal-overlay.visible .modal-content { transform: translateY(0); }
-        
+
+        .tool-help-content {
+            max-height: 90vh;
+        }
+
+        .tool-help-scroll {
+            overflow-y: auto;
+            padding-right: 0.25rem;
+            max-height: calc(90vh - 4.5rem);
+        }
+
+        .tool-help-table-wrapper {
+            overflow-x: auto;
+        }
+
+        .tool-help-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.95rem;
+        }
+
+        .tool-help-table th,
+        .tool-help-table td {
+            border: 1px solid var(--border-color);
+            padding: 0.5rem 0.75rem;
+            vertical-align: top;
+        }
+
+        .tool-help-table th {
+            background: var(--bg-tertiary);
+            color: var(--text-secondary);
+            font-weight: 600;
+        }
+
+        .tool-help-table tbody tr:nth-child(even) {
+            background: var(--table-row-alt, rgba(148, 163, 184, 0.08));
+        }
+
+        .tool-help-icon-cell {
+            width: 56px;
+            text-align: center;
+        }
+
+        .tool-help-icon-cell span {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 32px;
+            min-height: 32px;
+            font-size: 1.25rem;
+        }
+
+        .tool-help-code {
+            display: inline-flex;
+            align-items: center;
+            font-family: var(--font-mono, 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace);
+            background: var(--bg-tertiary);
+            color: var(--text-secondary);
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.375rem;
+            font-size: 0.85rem;
+        }
+
+        .tool-help-empty {
+            color: var(--text-muted, #6b7280);
+            font-style: italic;
+        }
+
         .notes-modal-content { max-width: 900px; height: 95vh; max-height: 95vh; padding: 0; }
 
         .notes-modal-content.fullscreen { max-width: 100vw; width: 100vw; height: 95vh; background: #F8FBFD; }

--- a/index.html
+++ b/index.html
@@ -25,10 +25,11 @@
             <div id="note-tabs"></div>
         </div>
         <button id="tabs-next" class="tab-nav hidden">▶</button>
+        <button id="tab-help-btn" class="tab-nav" title="Guía de herramientas" aria-label="Guía de herramientas">❔</button>
         <button id="tab-config-btn" class="tab-nav" title="Configuración">⚙️</button>
         <div id="tab-config-panel" class="hidden">
             <label><input type="checkbox" id="tab-bar-toggle" checked> Mostrar barra</label>
-            <label>Color: 
+            <label>Color:
                 <select id="tab-color-select">
                     <option value="#1f2937">Oscuro</option>
                     <option value="#1e3a8a">Azul</option>
@@ -44,6 +45,52 @@
                     <option value="right">Derecha</option>
                 </select>
             </label>
+        </div>
+    </div>
+
+    <div id="tool-help-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="tool-help-title" aria-hidden="true">
+        <div class="modal-content tool-help-content w-full max-w-5xl">
+            <div class="flex items-start justify-between gap-4 mb-4">
+                <div>
+                    <h2 id="tool-help-title" class="text-2xl font-bold text-primary">Guía de botones y ventanas</h2>
+                    <p class="text-sm text-gray-600 dark:text-gray-300">Consulta el nombre corto, código y función de cada herramienta para poder pedir cambios con precisión.</p>
+                </div>
+                <button id="tool-help-close-btn" class="toolbar-btn close-modal-btn" title="Cerrar" aria-label="Cerrar">✖</button>
+            </div>
+            <div class="tool-help-scroll space-y-6">
+                <section class="tool-help-section">
+                    <h3 class="text-lg font-semibold text-primary">Barra de edición de texto</h3>
+                    <div class="tool-help-table-wrapper">
+                        <table class="tool-help-table">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Icono</th>
+                                    <th scope="col">Nombre corto</th>
+                                    <th scope="col">Nombre código</th>
+                                    <th scope="col">Función</th>
+                                </tr>
+                            </thead>
+                            <tbody id="tool-help-toolbar-body"></tbody>
+                        </table>
+                    </div>
+                </section>
+                <section class="tool-help-section">
+                    <h3 class="text-lg font-semibold text-primary">Ventanas y paneles</h3>
+                    <div class="tool-help-table-wrapper">
+                        <table class="tool-help-table">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Icono</th>
+                                    <th scope="col">Nombre corto</th>
+                                    <th scope="col">Nombre código</th>
+                                    <th scope="col">Función</th>
+                                </tr>
+                            </thead>
+                            <tbody id="tool-help-windows-body"></tbody>
+                        </table>
+                    </div>
+                </section>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- add a help button to the tab bar and a modal with tables describing toolbar buttons and application windows
- style the help modal tables for readability within the existing theme
- register toolbar metadata so the modal stays in sync, including palettes, dropdowns, and manual controls

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cee8f8076c832c8758535f8214419d