### PR TITLE
Add help guide for editor and window controls

### DIFF
--- a/index.css
+++ b/index.css
@@ -104,7 +104,14 @@
         
         .modal-content { background: var(--modal-bg); color: var(--modal-text); padding: 1.5rem; border-radius: 0.5rem; width: 95%; box-shadow: 0 5px 15px rgba(0,0,0,0.3); transform: translateY(-20px); transition: transform 0.3s ease; display: flex; flex-direction: column; }
         .modal-overlay.visible .modal-content { transform: translateY(0); }
-        
+
+        .help-table { border-collapse: collapse; }
+        .help-table th, .help-table td { border: 1px solid var(--border-color); padding: 0.5rem; text-align: left; vertical-align: middle; }
+        .help-table .icon-cell { text-align: center; width: 3.5rem; font-size: 1.25rem; }
+        .help-table .icon-cell svg { width: 1.5rem; height: 1.5rem; display: inline-block; }
+        .help-table .code-cell { font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace; font-size: 0.85rem; }
+        .help-group-row td { background-color: var(--bg-tertiary); color: var(--text-secondary); font-weight: 600; }
+
         .notes-modal-content { max-width: 900px; height: 95vh; max-height: 95vh; padding: 0; }
 
         .notes-modal-content.fullscreen { max-width: 100vw; width: 100vw; height: 95vh; background: #F8FBFD; }

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
             <div id="note-tabs"></div>
         </div>
         <button id="tabs-next" class="tab-nav hidden">▶</button>
+        <button id="toolbar-help-btn" class="tab-nav" title="Guía de botones">❔</button>
         <button id="tab-config-btn" class="tab-nav" title="Configuración">⚙️</button>
         <div id="tab-config-panel" class="hidden">
             <label><input type="checkbox" id="tab-bar-toggle" checked> Mostrar barra</label>
@@ -416,7 +417,33 @@
             </div>
         </div>
     </div>
-    
+
+
+    <div id="toolbar-help-modal" class="modal-overlay">
+        <div class="modal-content w-full max-w-4xl">
+            <div class="flex items-start justify-between mb-4 gap-4">
+                <div>
+                    <h3 class="text-xl font-bold">Guía de botones</h3>
+                    <p class="text-sm text-text-secondary mt-1">Consulta el significado de cada control disponible en el editor y sus ventanas.</p>
+                </div>
+                <button id="toolbar-help-close" class="toolbar-btn" title="Cerrar guía">✖️</button>
+            </div>
+            <div class="overflow-x-auto">
+                <table class="w-full text-sm help-table">
+                    <thead>
+                        <tr>
+                            <th scope="col" class="w-20">Icono</th>
+                            <th scope="col">Nombre corto</th>
+                            <th scope="col" class="w-56">Nombre código</th>
+                            <th scope="col">Función</th>
+                        </tr>
+                    </thead>
+                    <tbody id="toolbar-help-table-body"></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
 
     <div id="html-code-modal" class="modal-overlay">
         <div class="modal-content w-full max-w-3xl">


### PR DESCRIPTION
## Summary
- add a "Guía de botones" entry in the tab bar that opens a modal with editor help
- capture toolbar, sub-nota toolbar, and window controls metadata to render a grouped reference table
- style the new help table for consistent icon, code, and description layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cee8f8076c832c8758535f8214419d