### PR TITLE
Implement note locking, color indicator, and table refinements

### DIFF
--- a/index.css
+++ b/index.css
@@ -3,7 +3,7 @@
         :root {
             --progress-ring-radius: 16;
             --progress-ring-circumference: calc(2 * 3.14159 * var(--progress-ring-radius));
-            
+
             --bg-primary: #f8fafc; --bg-secondary: #ffffff; --bg-tertiary: #f1f5f9;
             --text-primary: #1f2937; --text-secondary: #475569; --text-muted: #6b7280;
             --border-color: #e5e7eb;
@@ -15,8 +15,10 @@
             --filled-bg: #dcfce7; --filled-text: #166534;
             --not-done-bg: #fee2e2; --not-done-text: #991b1b;
             --lectura-filled-bg: #fef9c3; --lectura-filled-text: #854d0e;
+            --fullscreen-bg: #f8fbfd;
+            --fullscreen-editor-bg: #ffffff;
         }
-        html.dark { 
+        html.dark {
             color-scheme: dark;
             --bg-primary: #0f172a; --bg-secondary: #1e293b; --bg-tertiary: #334155;
             --text-primary: #cbd5e1; --text-secondary: #94a3b8; --text-muted: #64748b;
@@ -29,6 +31,8 @@
             --filled-bg: #14532d; --filled-text: #bbf7d0;
             --not-done-bg: #7f1d1d; --not-done-text: #fca5a5;
             --lectura-filled-bg: #713f12; --lectura-filled-text: #fde047;
+            --fullscreen-bg: #0f172a;
+            --fullscreen-editor-bg: #1e293b;
         }
         html[data-theme="ocean"] {
             --header-bg: #164e63;
@@ -107,12 +111,12 @@
         
         .notes-modal-content { max-width: 900px; height: 95vh; max-height: 95vh; padding: 0; }
 
-        .notes-modal-content.fullscreen { max-width: 100vw; width: 100vw; height: 95vh; background: #F8FBFD; }
+        .notes-modal-content.fullscreen { max-width: 100vw; width: 100vw; height: 95vh; background: var(--fullscreen-bg, #F8FBFD); }
         .notes-modal-content.fullscreen #notes-side-panel:not(.open),
         .notes-modal-content.fullscreen .resizer-e-panel { display: none; }
         .notes-modal-content.fullscreen #notes-main-content { flex-grow: 1; }
         .notes-modal-content.fullscreen #notes-editor {
-            background: #fff;
+            background: var(--fullscreen-editor-bg, #ffffff);
             border: 1px solid var(--border-color);
         }
 
@@ -574,8 +578,8 @@
             display: flex;
         }
 
-.preset-style-popup.preset-style-panel {
-    display: none;
+.preset-style-popup .preset-style-panel {
+    display: flex;
     flex-direction: column;
     gap: 0.35rem;
     min-width: 280px;
@@ -1295,6 +1299,57 @@ table.resizable-table th {
     z-index: 10000;
     max-width: 720px;
 }
+.table-menu-popup {
+    padding: 6px;
+    border-radius: 8px;
+    font-size: 0.8rem;
+}
+.notes-modal-content.locked-note #notes-editor {
+    cursor: not-allowed;
+    opacity: 0.95;
+}
+.notes-modal-content.locked-note #notes-modal-title {
+    pointer-events: none;
+    opacity: 0.75;
+}
+.editor-toolbar.locked {
+    pointer-events: none;
+    opacity: 0.55;
+}
+.editor-toolbar.locked .toolbar-btn,
+.editor-toolbar.locked .toolbar-select {
+    cursor: not-allowed;
+}
+.preset-style-target {
+    outline: 1px dashed var(--accent-color, var(--btn-primary-bg, #2563eb));
+    outline-offset: 2px;
+}
+.preset-style-indicator {
+    position: absolute;
+    width: 24px;
+    height: 24px;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: var(--bg-secondary, #fff);
+    border: 1px solid var(--border-color, #d1d5db);
+    border-radius: 999px;
+    box-shadow: 0 10px 18px rgba(15, 23, 42, 0.18);
+    font-size: 0.8rem;
+    color: var(--text-secondary, #475569);
+    cursor: pointer;
+    z-index: 10002;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.preset-style-indicator.visible {
+    display: inline-flex;
+}
+.preset-style-indicator:hover,
+.preset-style-indicator:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 22px rgba(15, 23, 42, 0.22);
+    outline: none;
+}
 .preset-style-popup .toolbar-btn {
     display: block;
     width: 100%;
@@ -1304,18 +1359,19 @@ table.resizable-table th {
 .table-menu-popup .tab-content {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.6rem;
     width: 100%;
     min-width: 0;
 }
 .table-menu-tabs {
     display: flex;
-    gap: 4px;
+    gap: 3px;
     margin-bottom: 4px;
 }
 .table-menu-tabs .tab-btn {
     flex: 1;
-    padding: 4px;
+    padding: 2px 4px;
+    font-size: 0.72rem;
 }
 .table-menu-tabs .tab-btn.active {
     background: var(--bg-tertiary);
@@ -1324,21 +1380,21 @@ table.resizable-table th {
 .table-edit-layout {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.75rem;
+    gap: 0.6rem;
     width: 100%;
 }
 .table-edit-group {
-    flex: 1 1 200px;
+    flex: 1 1 170px;
     background: var(--bg-tertiary);
     border: 1px solid var(--border-color);
-    border-radius: 0.75rem;
-    padding: 0.55rem;
+    border-radius: 0.55rem;
+    padding: 0.4rem;
     display: flex;
     flex-direction: column;
-    gap: 0.4rem;
+    gap: 0.3rem;
 }
 .table-edit-group-title {
-    font-size: 0.78rem;
+    font-size: 0.7rem;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.04em;
@@ -1347,11 +1403,11 @@ table.resizable-table th {
 .table-edit-btn {
     display: inline-flex;
     align-items: center;
-    gap: 0.45rem;
+    gap: 0.35rem;
     justify-content: flex-start;
     width: 100%;
-    border-radius: 0.65rem;
-    padding: 0.35rem 0.5rem;
+    border-radius: 0.5rem;
+    padding: 0.25rem 0.4rem;
     background: transparent;
 }
 .table-edit-btn:hover,
@@ -1382,19 +1438,19 @@ table.resizable-table th {
 }
 
 .table-style-column {
-    flex: 1 1 250px;
-    min-width: 220px;
+    flex: 1 1 220px;
+    min-width: 200px;
     display: flex;
     flex-direction: column;
     gap: 1rem;
 }
 
 .table-spacing-column {
-    max-width: 320px;
+    max-width: 280px;
 }
 
 .table-style-section-title {
-    font-size: 0.8rem;
+    font-size: 0.75rem;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.04em;
@@ -1403,19 +1459,19 @@ table.resizable-table th {
 
 .table-theme-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 0.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+    gap: 0.4rem;
 }
 
 .table-theme-option {
     border: 1px solid transparent;
-    border-radius: 0.75rem;
-    padding: 0.45rem;
+    border-radius: 0.55rem;
+    padding: 0.25rem;
     background: none;
     cursor: pointer;
     display: flex;
     flex-direction: column;
-    gap: 0.45rem;
+    gap: 0.3rem;
     text-align: left;
     transition: border-color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
 }
@@ -1432,10 +1488,10 @@ table.resizable-table th {
     display: grid;
     grid-template-rows: repeat(3, auto);
     border: 1px solid var(--table-preview-border, var(--border-color));
-    border-radius: 0.6rem;
+    border-radius: 0.45rem;
     overflow: hidden;
     box-shadow: inset 0 0 0 1px rgba(255,255,255,0.3);
-    min-height: 72px;
+    min-height: 40px;
 }
 
 .table-theme-preview .header-row {
@@ -1443,10 +1499,10 @@ table.resizable-table th {
     grid-template-columns: repeat(3, 1fr);
     background: var(--table-preview-header-bg);
     color: var(--table-preview-header-color);
-    font-size: 0.65rem;
+    font-size: 0.52rem;
     font-weight: 600;
     text-align: center;
-    padding: 4px 0;
+    padding: 2px 0;
 }
 
 .table-theme-preview .header-row span {
@@ -1463,7 +1519,7 @@ table.resizable-table th {
 }
 
 .table-theme-preview .body-row .cell {
-    height: 10px;
+    height: 4px;
     border-right: 1px solid var(--table-preview-border, var(--border-color));
     border-bottom: 1px solid var(--table-preview-border, var(--border-color));
 }
@@ -1485,7 +1541,7 @@ table.resizable-table th {
 }
 
 .table-theme-option-label {
-    font-size: 0.72rem;
+    font-size: 0.55rem;
     color: var(--text-secondary, #4b5563);
     display: block;
     text-align: center;
@@ -1494,14 +1550,14 @@ table.resizable-table th {
 .table-spacing-control {
     display: flex;
     flex-direction: column;
-    gap: 0.2rem;
+    gap: 0.15rem;
 }
 
 .table-spacing-label {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    font-size: 0.78rem;
+    font-size: 0.7rem;
     font-weight: 600;
     color: var(--text-secondary);
 }
@@ -1518,14 +1574,14 @@ table.resizable-table th {
 .table-spacing-presets {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.45rem;
+    gap: 0.35rem;
 }
 
 .table-spacing-btn {
-    flex: 1 1 140px;
-    border-radius: 0.65rem;
-    padding: 0.35rem 0.5rem;
-    font-size: 0.75rem;
+    flex: 1 1 120px;
+    border-radius: 0.5rem;
+    padding: 0.3rem 0.4rem;
+    font-size: 0.68rem;
     background: var(--bg-tertiary);
     border: 1px solid var(--border-color);
 }
@@ -1537,17 +1593,17 @@ table.resizable-table th {
 
 .table-header-list {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    gap: 0.5rem;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: 0.4rem;
 }
 
 .table-header-option {
     display: flex;
     align-items: center;
-    gap: 0.6rem;
+    gap: 0.45rem;
     border: 1px solid transparent;
-    border-radius: 0.65rem;
-    padding: 0.45rem 0.5rem;
+    border-radius: 0.5rem;
+    padding: 0.35rem 0.4rem;
     background: none;
     cursor: pointer;
     text-align: left;
@@ -1563,21 +1619,21 @@ table.resizable-table th {
 }
 
 .table-header-preview {
-    width: 56px;
-    height: 24px;
-    border-radius: 0.5rem;
+    width: 48px;
+    height: 20px;
+    border-radius: 0.4rem;
     border: 1px solid var(--table-header-border, var(--border-color));
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 0.7rem;
+    font-size: 0.62rem;
     font-weight: 600;
     color: var(--table-header-color, #1f2937);
     background: var(--table-header-bg, #f3f4f6);
 }
 
 .table-header-option-label {
-    font-size: 0.78rem;
+    font-size: 0.68rem;
     color: var(--text-secondary, #4b5563);
 }
 
@@ -1585,50 +1641,86 @@ table.resizable-table th {
 .table-theme-blue th, .table-theme-blue td { border:1px solid #2196f3; }
 .table-theme-blue th { background:#bbdefb; color:#0d47a1; }
 .table-theme-blue td { background:#ffffff; }
+.table-theme-blue tr:first-child td { background:#bbdefb; color:#0d47a1; font-weight:600; border-bottom-color:#2196f3; }
+.table-theme-blue tr:nth-child(odd):not(:first-child) td { background:#ffffff; }
+.table-theme-blue tr:nth-child(even):not(:first-child) td { background:#e3f2fd; }
 .table-theme-green { border-collapse: collapse; }
 .table-theme-green th, .table-theme-green td { border:1px solid #4caf50; }
 .table-theme-green th { background:#c8e6c9; color:#1b5e20; }
 .table-theme-green td { background:#ffffff; }
+.table-theme-green tr:first-child td { background:#c8e6c9; color:#1b5e20; font-weight:600; border-bottom-color:#4caf50; }
+.table-theme-green tr:nth-child(odd):not(:first-child) td { background:#ffffff; }
+.table-theme-green tr:nth-child(even):not(:first-child) td { background:#eaf5eb; }
 .table-theme-gray { border-collapse: collapse; }
 .table-theme-gray th, .table-theme-gray td { border:1px solid #9e9e9e; }
 .table-theme-gray th { background:#e0e0e0; color:#212121; }
 .table-theme-gray td { background:#ffffff; }
+.table-theme-gray tr:first-child td { background:#e0e0e0; color:#212121; font-weight:600; border-bottom-color:#9e9e9e; }
+.table-theme-gray tr:nth-child(odd):not(:first-child) td { background:#ffffff; }
+.table-theme-gray tr:nth-child(even):not(:first-child) td { background:#f7f7f7; }
 .table-theme-red { border-collapse: collapse; }
 .table-theme-red th, .table-theme-red td { border:1px solid #f44336; }
 .table-theme-red th { background:#ffcdd2; color:#b71c1c; }
 .table-theme-red td { background:#ffffff; }
+.table-theme-red tr:first-child td { background:#ffcdd2; color:#b71c1c; font-weight:600; border-bottom-color:#f44336; }
+.table-theme-red tr:nth-child(odd):not(:first-child) td { background:#ffffff; }
+.table-theme-red tr:nth-child(even):not(:first-child) td { background:#ffe7ea; }
 .table-theme-purple { border-collapse: collapse; }
 .table-theme-purple th, .table-theme-purple td { border:1px solid #9c27b0; }
 .table-theme-purple th { background:#e1bee7; color:#4a148c; }
 .table-theme-purple td { background:#ffffff; }
+.table-theme-purple tr:first-child td { background:#e1bee7; color:#4a148c; font-weight:600; border-bottom-color:#9c27b0; }
+.table-theme-purple tr:nth-child(odd):not(:first-child) td { background:#ffffff; }
+.table-theme-purple tr:nth-child(even):not(:first-child) td { background:#f5e9f7; }
 .table-theme-teal { border-collapse: collapse; }
 .table-theme-teal th, .table-theme-teal td { border:1px solid #009688; }
 .table-theme-teal th { background:#e0f2f1; color:#004d40; }
 .table-theme-teal td { background:#ffffff; }
+.table-theme-teal tr:first-child td { background:#e0f2f1; color:#004d40; font-weight:600; border-bottom-color:#009688; }
+.table-theme-teal tr:nth-child(odd):not(:first-child) td { background:#ffffff; }
+.table-theme-teal tr:nth-child(even):not(:first-child) td { background:#e8fffb; }
 .table-theme-amber { border-collapse: collapse; }
 .table-theme-amber th, .table-theme-amber td { border:1px solid #ffb300; }
 .table-theme-amber th { background:#ffecb3; color:#ff6f00; }
 .table-theme-amber td { background:#fffdf5; }
+.table-theme-amber tr:first-child td { background:#ffecb3; color:#ff6f00; font-weight:600; border-bottom-color:#ffb300; }
+.table-theme-amber tr:nth-child(odd):not(:first-child) td { background:#fffdf5; }
+.table-theme-amber tr:nth-child(even):not(:first-child) td { background:#fff5d7; }
 .table-theme-emerald { border-collapse: collapse; }
 .table-theme-emerald th, .table-theme-emerald td { border:1px solid #2e7d32; }
 .table-theme-emerald th { background:#b9f6ca; color:#1b5e20; }
 .table-theme-emerald td { background:#ffffff; }
+.table-theme-emerald tr:first-child td { background:#b9f6ca; color:#1b5e20; font-weight:600; border-bottom-color:#2e7d32; }
+.table-theme-emerald tr:nth-child(odd):not(:first-child) td { background:#ffffff; }
+.table-theme-emerald tr:nth-child(even):not(:first-child) td { background:#e6ffef; }
 .table-theme-rose { border-collapse: collapse; }
 .table-theme-rose th, .table-theme-rose td { border:1px solid #f06292; }
 .table-theme-rose th { background:#ffc1e3; color:#ad1457; }
 .table-theme-rose td { background:#fff6fb; }
+.table-theme-rose tr:first-child td { background:#ffc1e3; color:#ad1457; font-weight:600; border-bottom-color:#f06292; }
+.table-theme-rose tr:nth-child(odd):not(:first-child) td { background:#fff6fb; }
+.table-theme-rose tr:nth-child(even):not(:first-child) td { background:#ffe0ef; }
 .table-theme-slate { border-collapse: collapse; }
 .table-theme-slate th, .table-theme-slate td { border:1px solid #607d8b; }
 .table-theme-slate th { background:#cfd8dc; color:#29434e; }
 .table-theme-slate td { background:#ffffff; }
+.table-theme-slate tr:first-child td { background:#cfd8dc; color:#29434e; font-weight:600; border-bottom-color:#607d8b; }
+.table-theme-slate tr:nth-child(odd):not(:first-child) td { background:#ffffff; }
+.table-theme-slate tr:nth-child(even):not(:first-child) td { background:#f5f7f8; }
 .table-theme-sunrise { border-collapse: collapse; }
 .table-theme-sunrise th, .table-theme-sunrise td { border:1px solid #ff7043; }
 .table-theme-sunrise th { background:#ffe0b2; color:#e65100; }
 .table-theme-sunrise td { background:#fffaf5; }
+.table-theme-sunrise tr:first-child td { background:#ffe0b2; color:#e65100; font-weight:600; border-bottom-color:#ff7043; }
+.table-theme-sunrise tr:nth-child(odd):not(:first-child) td { background:#fffaf5; }
+.table-theme-sunrise tr:nth-child(even):not(:first-child) td { background:#ffe8d9; }
 .table-theme-indigo { border-collapse: collapse; }
 .table-theme-indigo th, .table-theme-indigo td { border:1px solid #3949ab; }
 .table-theme-indigo th { background:#c5cae9; color:#1a237e; }
 .table-theme-indigo td { background:#ffffff; }
+.table-theme-indigo tr:first-child td { background:#c5cae9; color:#1a237e; font-weight:600; border-bottom-color:#3949ab; }
+.table-theme-indigo tr:nth-child(odd):not(:first-child) td { background:#ffffff; }
+.table-theme-indigo tr:nth-child(even):not(:first-child) td { background:#e8eaf6; }
 .note-resizable {
     resize: horizontal;
     overflow: auto;

--- a/index.html
+++ b/index.html
@@ -27,9 +27,11 @@
         <button id="tabs-next" class="tab-nav hidden">▶</button>
         <button id="tab-guide-btn" class="tab-nav" title="Guía de controles">❔</button>
         <button id="tab-config-btn" class="tab-nav" title="Configuración">⚙️</button>
+        <button id="fullscreen-bg-btn" class="tab-nav" title="Color de fondo pantalla amplia" aria-label="Color de fondo en pantalla amplia">🎨</button>
+        <input type="color" id="fullscreen-bg-input" class="hidden" value="#f8fbfd">
         <div id="tab-config-panel" class="hidden">
             <label><input type="checkbox" id="tab-bar-toggle" checked> Mostrar barra</label>
-            <label>Color: 
+            <label>Color:
                 <select id="tab-color-select">
                     <option value="#1f2937">Oscuro</option>
                     <option value="#1e3a8a">Azul</option>
@@ -386,6 +388,9 @@
                             </button>
                             <button id="toggle-readonly-btn" class="toolbar-btn" title="Modo Lectura/Edición">
                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-eye w-5 h-5"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
+                            </button>
+                            <button id="lock-note-btn" class="toolbar-btn" title="Bloquear nota" aria-pressed="false">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-unlock w-5 h-5"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 9.9-1"></path></svg>
                             </button>
                             <button id="import-note-btn" class="toolbar-btn" title="Importar desde HTML">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-upload w-5 h-5"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" x2="12" y1="3" y2="15"/></svg>


### PR DESCRIPTION
## Summary
- add a fullscreen background color picker with persistent storage and update theme handling
- implement per-note locking with toolbar/UI state sync and persist the lock flag in saved notes
- rebuild the preset style popup to open via an inline indicator and compact the table design tools while preserving themed styles when editing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cef2a28968832c831323e0b941cea4