### PR TITLE
feat: enhance text tools and table controls

### DIFF
--- a/index.css
+++ b/index.css
@@ -577,6 +577,32 @@
         .symbol-dropdown { position: relative; display: inline-block; }
         .symbol-dropdown-content { display: none; position: absolute; top: 100%; left: 0; background-color: var(--bg-secondary); min-width: 280px; max-height: 200px; overflow-y: auto; box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2); z-index: 10; border-radius: 8px; border: 1px solid var(--border-color); padding: 8px; grid-template-columns: repeat(auto-fill, minmax(32px, 1fr)); gap: 4px; }
         .symbol-dropdown-content.visible { display: grid; }
+        .symbol-dropdown-content.bullet-style-menu {
+            display: none;
+            flex-direction: column;
+            gap: 4px;
+            min-width: 180px;
+        }
+        .symbol-dropdown-content.bullet-style-menu.visible {
+            display: flex !important;
+        }
+        .bullet-style-option {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            justify-content: flex-start;
+        }
+        .bullet-style-option .bullet-preview {
+            font-size: 1.1rem;
+            width: 1.5rem;
+            text-align: center;
+            line-height: 1;
+        }
+        .bullet-style-option .bullet-option-label {
+            flex: 1;
+            font-size: 0.85rem;
+            text-align: left;
+        }
         .symbol-btn {
             font-size: 18px;
             text-align: center;
@@ -1369,6 +1395,114 @@ table.resizable-table th {
     width: 100%;
     text-align: left;
     margin: 2px 0;
+}
+
+.styled-style-popup {
+    position: absolute;
+    background: var(--bg-secondary, #fff);
+    border: 1px solid var(--border-color, #ccc);
+    border-radius: 12px;
+    padding: 12px;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.2);
+    display: none;
+    flex-direction: column;
+    gap: 12px;
+    width: min(520px, calc(100vw - 48px));
+    max-height: min(420px, calc(100vh - 48px));
+    overflow-y: auto;
+    z-index: 10000;
+}
+.styled-style-popup.visible {
+    display: flex;
+}
+.styled-style-popup-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+.styled-style-popup-close {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-size: 1.1rem;
+    cursor: pointer;
+    line-height: 1;
+}
+.styled-style-popup-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 10px;
+}
+.styled-style-card {
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 10px;
+    background: var(--bg-tertiary);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.styled-style-main {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 8px;
+    border-radius: 8px;
+    border: 1px solid transparent;
+    background: var(--bg-secondary);
+}
+.styled-style-main:hover,
+.styled-style-main:focus-visible,
+.styled-style-variant-btn:hover,
+.styled-style-variant-btn:focus-visible {
+    border-color: var(--btn-primary-bg);
+}
+.styled-style-preview {
+    flex: 1;
+    min-width: 0;
+    border-radius: 6px;
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
+    padding: 4px 6px;
+    font-weight: 600;
+    font-size: 0.85rem;
+    display: block;
+}
+.styled-style-variants {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+.styled-style-variant-btn {
+    flex: 1 1 90px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    border-radius: 8px;
+    border: 1px solid transparent;
+    background: var(--bg-secondary);
+    padding: 6px;
+    text-align: left;
+}
+.styled-style-variant-label {
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+}
+
+.line-erase-selection {
+    position: fixed;
+    border: 2px dashed var(--btn-primary-bg, #3b82f6);
+    background-color: rgba(59, 130, 246, 0.12);
+    pointer-events: none;
+    display: none;
+    z-index: 10002;
+}
+.line-erase-selection.active {
+    display: block;
 }
 .table-menu-popup .tab-content {
     display: flex;


### PR DESCRIPTION
## Summary
- add blank-line-below control, bullet style menu, refined delete-line logic, and area-based erase mode
- redesign the styled text popup with a double-click trigger and improved layout
- restrict table menu activation, add table margin controls, and update related styling helpers

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d08f266f20832c85fc552bb9755a4a