### PR TITLE
Improve table resizing and add floating formatting toolbar

### DIFF
--- a/index.css
+++ b/index.css
@@ -1626,6 +1626,22 @@ table.resizable-table th {
     margin: 2px 0;
 }
 
+.preset-style-popup .pill-style-btn {
+    padding: 2px 4px;
+    border-radius: 4px;
+}
+
+.preset-style-popup .pill-style-btn span {
+    display: block;
+    font-size: 0.75rem;
+    text-align: center;
+}
+
+.preset-style-popup .pill-style-btn.active {
+    outline: 2px solid var(--btn-primary-bg, #2563eb);
+    outline-offset: 1px;
+}
+
 .inline-style-popup {
     width: min(320px, calc(100vw - 32px));
     font-size: 0.8rem;


### PR DESCRIPTION
## Summary
- make the table menu open on double-click and ensure resize mode shows the corner handle, with escape handling to exit
- introduce a floating formatting toolbar that appears on text selection with bold, italic, underline, superscript, and color pickers
- add a Tailwind spacing adjustment panel in the main toolbar and supporting styles for the new controls

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8b8d57dcc832c9981637c0afde4ff