### PR TITLE
Restore pill-text styling on saved selections

### DIFF
--- a/index.css
+++ b/index.css
@@ -580,6 +580,229 @@
             left: 0;
         }
 
+        .floating-format-toolbar {
+            position: absolute;
+            display: none;
+            align-items: center;
+            gap: 4px;
+            background-color: rgba(17, 24, 39, 0.92);
+            color: #f8fafc;
+            padding: 6px 8px;
+            border-radius: 8px;
+            box-shadow: 0 12px 24px rgba(15, 23, 42, 0.25);
+            z-index: 10020;
+            backdrop-filter: blur(6px);
+        }
+
+        .floating-format-toolbar.visible {
+            display: flex;
+        }
+
+        .floating-toolbar-btn {
+            color: inherit;
+            background: transparent;
+        }
+
+        .floating-toolbar-btn b,
+        .floating-toolbar-btn i,
+        .floating-toolbar-btn u {
+            color: inherit;
+        }
+
+        .floating-toolbar-btn svg {
+            fill: currentColor;
+        }
+
+        .floating-format-toolbar .floating-toolbar-btn:hover,
+        .floating-format-toolbar .floating-toolbar-btn.active {
+            background-color: rgba(255, 255, 255, 0.16);
+        }
+
+        .floating-color-control {
+            position: relative;
+        }
+
+        .floating-color-menu {
+            position: absolute;
+            top: 110%;
+            left: 50%;
+            transform: translateX(-50%);
+            display: none;
+            padding: 6px;
+            border-radius: 8px;
+            background: var(--bg-secondary);
+            border: 1px solid var(--border-color);
+            box-shadow: 0 10px 20px rgba(15, 23, 42, 0.25);
+            z-index: 10021;
+            max-width: 220px;
+            grid-template-columns: repeat(6, 1fr);
+            gap: 4px;
+        }
+
+        .floating-color-menu.visible {
+            display: grid;
+        }
+
+        .floating-color-menu .color-swatch {
+            width: 18px;
+            height: 18px;
+        }
+
+        .floating-color-divider {
+            grid-column: 1 / -1;
+            height: 1px;
+            background: var(--border-color);
+            margin: 2px 0;
+        }
+
+        .floating-style-menu {
+            position: absolute;
+            display: none;
+            flex-direction: column;
+            gap: 0.5rem;
+            padding: 12px;
+            background: var(--bg-secondary);
+            border: 1px solid var(--border-color);
+            border-radius: 12px;
+            box-shadow: 0 18px 32px rgba(15, 23, 42, 0.25);
+            min-width: 260px;
+            max-width: min(420px, 90vw);
+            max-height: 70vh;
+            overflow-y: auto;
+            z-index: 10022;
+        }
+
+        .floating-style-menu.visible {
+            display: flex;
+        }
+
+        .spacing-adjuster {
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+        }
+
+        .spacing-adjuster-panel {
+            position: absolute;
+            display: none;
+            flex-direction: column;
+            gap: 12px;
+            top: calc(100% + 6px);
+            right: 0;
+            background: var(--bg-secondary);
+            border: 1px solid var(--border-color);
+            border-radius: 12px;
+            padding: 14px 16px;
+            box-shadow: 0 16px 30px rgba(15, 23, 42, 0.18);
+            min-width: 240px;
+            z-index: 1010;
+        }
+
+        .spacing-adjuster-panel.visible {
+            display: flex;
+        }
+
+        .spacing-adjuster-field {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            font-size: 0.8rem;
+        }
+
+        .spacing-slider-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            font-weight: 600;
+            color: var(--text-secondary);
+        }
+
+        .spacing-slider-value {
+            font-size: 0.75rem;
+            padding: 2px 6px;
+            border-radius: 999px;
+            background: var(--bg-tertiary);
+            color: var(--text-secondary);
+        }
+
+        .spacing-slider-input {
+            -webkit-appearance: none;
+            appearance: none;
+            width: 100%;
+            height: 6px;
+            border-radius: 999px;
+            background: rgba(148, 163, 184, 0.25);
+            position: relative;
+        }
+
+        .spacing-slider-input::-webkit-slider-runnable-track {
+            height: 6px;
+            border-radius: 999px;
+            background: transparent;
+        }
+
+        .spacing-slider-input::-moz-range-track {
+            height: 6px;
+            border-radius: 999px;
+            background: transparent;
+        }
+
+        .spacing-slider-input::-webkit-slider-thumb {
+            -webkit-appearance: none;
+            appearance: none;
+            width: 16px;
+            height: 16px;
+            border-radius: 50%;
+            background: #0ea5e9;
+            border: 2px solid var(--bg-secondary);
+            box-shadow: 0 4px 8px rgba(14, 165, 233, 0.35);
+            cursor: pointer;
+        }
+
+        .spacing-slider-input::-moz-range-thumb {
+            width: 16px;
+            height: 16px;
+            border-radius: 50%;
+            background: #0ea5e9;
+            border: 2px solid var(--bg-secondary);
+            box-shadow: 0 4px 8px rgba(14, 165, 233, 0.35);
+            cursor: pointer;
+        }
+
+        .spacing-slider-input:focus-visible {
+            outline: 2px solid #38bdf8;
+            outline-offset: 2px;
+        }
+
+        .spacing-adjuster-footer {
+            display: flex;
+            gap: 8px;
+        }
+
+        .spacing-apply-btn,
+        .spacing-clear-btn {
+            font-size: 0.8rem;
+            padding: 6px 10px;
+            flex: 1 1 auto;
+        }
+
+        .spacing-apply-btn {
+            background: linear-gradient(90deg, #0ea5e9, #38bdf8);
+            color: #fff;
+        }
+
+        .spacing-apply-btn:hover {
+            filter: brightness(1.05);
+        }
+
+        .spacing-clear-btn {
+            background: var(--bg-tertiary);
+        }
+
+        .spacing-clear-btn:hover {
+            filter: brightness(0.97);
+        }
+
         .symbol-dropdown { position: relative; display: inline-block; }
         .symbol-dropdown-content { display: none; position: absolute; top: 100%; left: 0; background-color: var(--bg-secondary); min-width: 280px; max-height: 200px; overflow-y: auto; box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2); z-index: 10; border-radius: 8px; border: 1px solid var(--border-color); padding: 8px; grid-template-columns: repeat(auto-fill, minmax(32px, 1fr)); gap: 4px; }
         .symbol-dropdown-content.visible { display: grid; }
@@ -627,10 +850,10 @@
         .symbol-dropdown-content.preset-style-panel {
             display: none;
             flex-direction: column;
-            gap: 0.5rem;
-            padding: 6px 8px;
-            min-width: 280px;
-            max-height: 75vh;
+            gap: 0.35rem;
+            padding: 4px 6px;
+            min-width: 220px;
+            max-height: 70vh;
             overflow-y: auto;
         }
 
@@ -641,19 +864,19 @@
 .preset-style-popup.preset-style-panel {
     display: none;
     flex-direction: column;
-    gap: 0.5rem;
-    min-width: 280px;
-    max-height: 75vh;
+    gap: 0.35rem;
+    min-width: 220px;
+    max-height: 70vh;
     overflow-y: auto;
-    padding: 6px 8px;
+    padding: 4px 6px;
 }
 
 .preset-style-panel-header {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.25rem 0.35rem 0;
-    font-size: 0.85rem;
+    gap: 0.35rem;
+    padding: 0.15rem 0.25rem 0;
+    font-size: 0.78rem;
     font-weight: 700;
     letter-spacing: 0.03em;
     text-transform: uppercase;
@@ -661,7 +884,7 @@
 }
 
 .preset-style-panel-icon {
-    font-size: 1.15rem;
+    font-size: 1rem;
     line-height: 1;
 }
 
@@ -672,16 +895,16 @@
 .preset-style-options {
     display: flex;
     flex-direction: column;
-    gap: 0.45rem;
+    gap: 0.3rem;
 }
 
 .preset-style-option {
     border: 1px solid transparent;
-    border-radius: 0.75rem;
-    padding: 0.35rem 0.45rem;
+    border-radius: 0.6rem;
+    padding: 0.25rem 0.35rem;
     display: flex;
     flex-direction: column;
-    gap: 0.45rem;
+    gap: 0.3rem;
     transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -695,7 +918,7 @@
 .preset-style-row {
     display: flex;
     align-items: stretch;
-    gap: 0.5rem;
+    gap: 0.35rem;
 }
 
 .preset-style-main {
@@ -720,10 +943,10 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 0.6rem;
+    gap: 0.4rem;
     width: 100%;
-    border-radius: 0.65rem;
-    padding: 0.35rem 0.6rem;
+    border-radius: 0.45rem;
+    padding: 0.25rem 0.45rem;
     box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.04);
     transition: transform 0.15s ease;
 }
@@ -738,7 +961,7 @@
 .preset-style-label {
     flex: 1;
     min-width: 0;
-    font-size: 0.92rem;
+    font-size: 0.82rem;
     font-weight: 600;
     text-transform: capitalize;
     white-space: nowrap;
@@ -747,12 +970,12 @@
 }
 
 .preset-style-variant-badge {
-    font-size: 0.7rem;
+    font-size: 0.62rem;
     font-weight: 600;
-    padding: 0.2rem 0.45rem;
+    padding: 0.15rem 0.35rem;
     border-radius: 999px;
-    border: 1px solid rgba(255, 255, 255, 0.45);
-    background-color: rgba(255, 255, 255, 0.4);
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    background-color: rgba(255, 255, 255, 0.35);
     color: inherit;
     letter-spacing: 0.03em;
     text-transform: uppercase;
@@ -778,10 +1001,10 @@
 .preset-style-variants {
     display: flex;
     flex-direction: column;
-    gap: 0.3rem;
-    padding-left: 0.75rem;
-    margin-top: 0.2rem;
-    margin-left: 0.35rem;
+    gap: 0.2rem;
+    padding-left: 0.5rem;
+    margin-top: 0.15rem;
+    margin-left: 0.25rem;
     border-left: 1px dashed var(--border-color);
 }
 
@@ -1388,13 +1611,13 @@ table.resizable-table th {
     position: absolute;
     background: var(--bg-secondary, #fff);
     border: 1px solid var(--border-color, #ccc);
-    padding: 8px;
-    border-radius: 8px;
-    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.2);
+    padding: 6px;
+    border-radius: 6px;
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.18);
     display: none;
     z-index: 10000;
     max-width: 720px;
-    font-size: 0.85rem;
+    font-size: 0.82rem;
 }
 .preset-style-popup .toolbar-btn {
     display: block;
@@ -1403,100 +1626,9 @@ table.resizable-table th {
     margin: 2px 0;
 }
 
-.styled-style-popup {
-    position: absolute;
-    background: var(--bg-secondary, #fff);
-    border: 1px solid var(--border-color, #ccc);
-    border-radius: 12px;
-    padding: 12px;
-    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.2);
-    display: none;
-    flex-direction: column;
-    gap: 12px;
-    width: min(520px, calc(100vw - 48px));
-    max-height: min(420px, calc(100vh - 48px));
-    overflow-y: auto;
-    z-index: 10000;
-}
-.styled-style-popup.visible {
-    display: flex;
-}
-.styled-style-popup-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    font-weight: 600;
-    font-size: 0.9rem;
-}
-.styled-style-popup-close {
-    background: none;
-    border: none;
-    color: var(--text-muted);
-    font-size: 1.1rem;
-    cursor: pointer;
-    line-height: 1;
-}
-.styled-style-popup-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 10px;
-}
-.styled-style-card {
-    border: 1px solid var(--border-color);
-    border-radius: 10px;
-    padding: 10px;
-    background: var(--bg-tertiary);
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-}
-.styled-style-main {
-    display: flex;
-    gap: 8px;
-    align-items: center;
-    justify-content: space-between;
-    padding: 6px 8px;
-    border-radius: 8px;
-    border: 1px solid transparent;
-    background: var(--bg-secondary);
-}
-.styled-style-main:hover,
-.styled-style-main:focus-visible,
-.styled-style-variant-btn:hover,
-.styled-style-variant-btn:focus-visible {
-    border-color: var(--btn-primary-bg);
-}
-.styled-style-preview {
-    flex: 1;
-    min-width: 0;
-    border-radius: 6px;
-    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
-    padding: 4px 6px;
-    font-weight: 600;
-    font-size: 0.85rem;
-    display: block;
-}
-.styled-style-variants {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-}
-.styled-style-variant-btn {
-    flex: 1 1 90px;
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    border-radius: 8px;
-    border: 1px solid transparent;
-    background: var(--bg-secondary);
-    padding: 6px;
-    text-align: left;
-}
-.styled-style-variant-label {
-    font-size: 0.7rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    color: var(--text-secondary);
+.inline-style-popup {
+    width: min(320px, calc(100vw - 32px));
+    font-size: 0.8rem;
 }
 
 .line-erase-selection {
@@ -1513,63 +1645,83 @@ table.resizable-table th {
 .table-menu-popup .tab-content {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.4rem;
     width: 100%;
     min-width: 0;
 }
 .table-menu-tabs {
     display: flex;
-    gap: 2px;
+    gap: 4px;
     margin-bottom: 4px;
 }
 .table-menu-tabs .tab-btn {
     flex: 1;
-    padding: 2px 4px;
+    padding: 3px 4px;
+    font-size: 0.75rem;
 }
 .table-menu-tabs .tab-btn.active {
     background: var(--bg-tertiary);
     font-weight: bold;
 }
-.table-edit-layout {
+.table-menu-header {
     display: flex;
-    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
     gap: 0.5rem;
-    width: 100%;
+    margin-bottom: 4px;
 }
-.table-edit-group {
-    flex: 1 1 180px;
-    background: var(--bg-tertiary);
-    border: 1px solid var(--border-color);
-    border-radius: 0.6rem;
-    padding: 0.4rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.35rem;
-}
-.table-edit-group-title {
+.table-menu-summary {
     font-size: 0.72rem;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.04em;
     color: var(--text-secondary);
 }
-.table-edit-btn {
+.table-header-btn {
     display: inline-flex;
     align-items: center;
-    gap: 0.3rem;
-    justify-content: flex-start;
-    width: 100%;
-    border-radius: 0.55rem;
-    padding: 0.3rem 0.45rem;
-    background: transparent;
+    gap: 0.35rem;
+    padding: 0.25rem 0.4rem;
+    font-size: 0.75rem;
 }
-.table-edit-btn:hover,
-.table-edit-btn:focus-visible {
-    background: var(--bg-secondary);
-    box-shadow: inset 0 0 0 1px var(--border-color);
-}
-.table-edit-icon {
+.table-menu-icon {
     font-size: 0.85rem;
+    line-height: 1;
+}
+.table-menu-label {
+    line-height: 1;
+}
+.table-quick-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(108px, 1fr));
+    gap: 0.35rem;
+}
+.table-quick-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    justify-content: flex-start;
+    border-radius: 0.5rem;
+    padding: 0.3rem 0.4rem;
+    font-size: 0.8rem;
+}
+.table-quick-action .table-quick-icon {
+    font-size: 0.85rem;
+    line-height: 1;
+}
+.table-quick-label {
+    flex: 1;
+    text-align: left;
+}
+.table-quick-action.active {
+    background: var(--bg-secondary);
+    box-shadow: inset 0 0 0 1px var(--btn-primary-bg, var(--border-color));
+}
+.table-menu-hint {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    margin: 0;
+    padding: 0 0.1rem;
 }
 .line-style-group {
     display: flex;
@@ -1725,6 +1877,20 @@ table.resizable-table th {
 
 .table-theme-preview .body-row:nth-child(2) .cell {
     background: var(--table-preview-row2-bg, #f9fafb);
+}
+
+table.table-striped tbody tr:nth-child(even) td,
+table.table-striped tbody tr:nth-child(even) th,
+table.table-striped tr:nth-child(even):not(:first-child) td,
+table.table-striped tr:nth-child(even):not(:first-child) th {
+    background-color: rgba(148, 163, 184, 0.14);
+}
+
+table.table-striped thead tr th,
+table.table-striped thead tr td,
+table.table-striped tr:first-child th,
+table.table-striped tr:first-child td {
+    background-color: inherit;
 }
 
 .table-theme-option-label {

--- a/index.js
+++ b/index.js
@@ -1632,9 +1632,12 @@ document.addEventListener('DOMContentLoaded', function () {
     let activeTooltipState = null;
     let editingQuickNote = false;
     let savedEditorSelection = null;
+    let dismissFloatingToolbar = () => {};
     let savedSelectedHtml = '';
     let currentCallout = null;
     let lineEraseMode = false;
+    let floatingToolbar = null;
+    let floatingToolbarInitialized = false;
 
     // Image selection handling within the sub-note editor
     if (subNoteEditor) {
@@ -2715,6 +2718,10 @@ ${exportTable.outerHTML}
 
     function setupEditorToolbar() {
         editorToolbar.innerHTML = ''; // Clear existing toolbar
+        if (!editorToolbar.dataset.hideFloatingBound) {
+            editorToolbar.addEventListener('mousedown', () => dismissFloatingToolbar(), { capture: true });
+            editorToolbar.dataset.hideFloatingBound = 'true';
+        }
 
         // Run a callback while preserving the current text selection
         const withEditorSelection = (fn) => {
@@ -2739,6 +2746,7 @@ ${exportTable.outerHTML}
             btn.addEventListener('mousedown', e => e.preventDefault());
             btn.addEventListener('click', (e) => {
                 e.preventDefault();
+                dismissFloatingToolbar();
                 withEditorSelection(() => {
                     if (command) {
                         document.execCommand(command, false, value);
@@ -3622,6 +3630,287 @@ ${exportTable.outerHTML}
             return sep;
         };
         
+        const removeTailwindSpacingClasses = (element) => {
+            if (!element || !element.classList) return;
+            const classesToRemove = Array.from(element.classList).filter(cls => /^(?:m[trblxy]|space-y)-/i.test(cls));
+            classesToRemove.forEach(cls => element.classList.remove(cls));
+        };
+
+        const createTailwindSpacingControl = () => {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'spacing-adjuster';
+
+            const toggleBtn = document.createElement('button');
+            toggleBtn.className = 'toolbar-btn spacing-adjuster-toggle';
+            toggleBtn.type = 'button';
+            toggleBtn.title = 'Ajustar márgenes y espacio vertical';
+            toggleBtn.innerHTML = '↕️⚙️';
+            toggleBtn.addEventListener('mousedown', (e) => e.preventDefault());
+
+            const panel = document.createElement('div');
+            panel.className = 'spacing-adjuster-panel';
+
+            let spacingSelection = null;
+
+            const ensureSelection = () => {
+                if (!spacingSelection) return;
+                const selection = window.getSelection();
+                if (!selection) return;
+                selection.removeAllRanges();
+                selection.addRange(spacingSelection.cloneRange());
+            };
+
+            const updateStoredSelection = () => {
+                const selection = window.getSelection();
+                if (selection && selection.rangeCount > 0) {
+                    spacingSelection = selection.getRangeAt(0).cloneRange();
+                    savedEditorSelection = spacingSelection.cloneRange();
+                }
+            };
+
+            const applySpacing = (topValue, bottomValue, betweenValue) => {
+                const blocks = getSelectedBlockElements();
+                const topPx = topValue !== null ? `${topValue}px` : null;
+                const bottomPx = bottomValue !== null ? `${bottomValue}px` : null;
+                const betweenPx = betweenValue !== null ? `${betweenValue}px` : null;
+
+                const processedParents = new WeakSet();
+
+                blocks.forEach((block, index) => {
+                    if (!block || !notesEditor.contains(block)) return;
+                    removeTailwindSpacingClasses(block);
+                    if (block.parentElement && block.parentElement !== notesEditor && !processedParents.has(block.parentElement)) {
+                        removeTailwindSpacingClasses(block.parentElement);
+                        if (betweenPx !== null) {
+                            block.parentElement.style.gap = betweenPx;
+                            block.parentElement.style.rowGap = betweenPx;
+                            block.parentElement.dataset.customSpaceY = betweenPx;
+                        } else {
+                            block.parentElement.style.removeProperty('gap');
+                            block.parentElement.style.removeProperty('row-gap');
+                            delete block.parentElement.dataset.customSpaceY;
+                        }
+                        processedParents.add(block.parentElement);
+                    }
+
+                    if (betweenPx !== null) {
+                        const isSingle = blocks.length === 1;
+                        if (isSingle) {
+                            block.style.marginTop = betweenPx;
+                            block.style.marginBottom = betweenPx;
+                        } else {
+                            if (index === 0) {
+                                block.style.marginBottom = betweenPx;
+                                block.style.marginTop = topPx !== null ? topPx : '';
+                            } else if (index === blocks.length - 1) {
+                                block.style.marginTop = betweenPx;
+                                block.style.marginBottom = bottomPx !== null ? bottomPx : '';
+                            } else {
+                                block.style.marginTop = betweenPx;
+                                block.style.marginBottom = betweenPx;
+                            }
+                        }
+                    } else {
+                        if (topPx !== null) {
+                            block.style.marginTop = topPx;
+                        } else {
+                            block.style.removeProperty('margin-top');
+                        }
+                        if (bottomPx !== null) {
+                            block.style.marginBottom = bottomPx;
+                        } else {
+                            block.style.removeProperty('margin-bottom');
+                        }
+                    }
+                });
+            };
+
+            const sliderRefs = {};
+
+            const updateSliderVisual = (slider, badge) => {
+                const value = Number(slider.value);
+                const min = Number(slider.min);
+                const max = Number(slider.max);
+                const percent = max > min ? ((value - min) / (max - min)) * 100 : 0;
+                slider.style.background = `linear-gradient(90deg, #0ea5e9 0%, #38bdf8 ${percent}%, rgba(148,163,184,0.25) ${percent}%)`;
+                badge.textContent = `${value} px`;
+            };
+
+            const handleLiveSpacing = () => {
+                if (!spacingSelection) return;
+                ensureSelection();
+                const topValue = Number(sliderRefs.top.slider.value);
+                const bottomValue = Number(sliderRefs.bottom.slider.value);
+                const betweenValue = Number(sliderRefs.between.slider.value);
+                withEditorSelection(() => applySpacing(topValue, bottomValue, betweenValue));
+                Object.values(sliderRefs).forEach(ref => ref.update());
+                updateStoredSelection();
+            };
+
+            const buildSlider = (labelText, { min = 0, max = 96, step = 1 } = {}) => {
+                const field = document.createElement('div');
+                field.className = 'spacing-adjuster-field';
+
+                const header = document.createElement('div');
+                header.className = 'spacing-slider-header';
+
+                const label = document.createElement('span');
+                label.textContent = labelText;
+
+                const badge = document.createElement('span');
+                badge.className = 'spacing-slider-value';
+                badge.textContent = '0 px';
+
+                header.appendChild(label);
+                header.appendChild(badge);
+                field.appendChild(header);
+
+                const slider = document.createElement('input');
+                slider.type = 'range';
+                slider.className = 'spacing-slider-input';
+                slider.min = String(min);
+                slider.max = String(max);
+                slider.step = String(step);
+                slider.value = '0';
+
+                field.appendChild(slider);
+                panel.appendChild(field);
+
+                slider.addEventListener('input', () => {
+                    updateSliderVisual(slider, badge);
+                    handleLiveSpacing();
+                });
+                slider.addEventListener('change', () => {
+                    updateSliderVisual(slider, badge);
+                    updateStoredSelection();
+                });
+                slider.addEventListener('pointerdown', ensureSelection);
+                slider.addEventListener('touchstart', ensureSelection, { passive: true });
+
+                const update = () => updateSliderVisual(slider, badge);
+                update();
+
+                return { slider, badge, update };
+            };
+
+            sliderRefs.top = buildSlider('Margen superior (px)', { max: 120 });
+            sliderRefs.bottom = buildSlider('Margen inferior (px)', { max: 120 });
+            sliderRefs.between = buildSlider('Espacio entre bloques (px)', { max: 120 });
+
+            const clearBtn = document.createElement('button');
+            clearBtn.type = 'button';
+            clearBtn.className = 'toolbar-btn spacing-clear-btn';
+            clearBtn.textContent = 'Restablecer';
+            clearBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                if (!spacingSelection) return;
+                Object.values(sliderRefs).forEach(ref => {
+                    ref.slider.value = '0';
+                    ref.update();
+                });
+                ensureSelection();
+                withEditorSelection(() => applySpacing(null, null, null));
+                updateStoredSelection();
+                hidePanel();
+                notesEditor.focus({ preventScroll: true });
+            });
+
+            const closeBtn = document.createElement('button');
+            closeBtn.type = 'button';
+            closeBtn.className = 'toolbar-btn spacing-apply-btn';
+            closeBtn.textContent = 'Cerrar';
+            closeBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                hidePanel();
+                notesEditor.focus({ preventScroll: true });
+            });
+
+            const footer = document.createElement('div');
+            footer.className = 'spacing-adjuster-footer';
+            footer.appendChild(clearBtn);
+            footer.appendChild(closeBtn);
+            panel.appendChild(footer);
+
+            const clampValue = (value, slider) => {
+                const min = Number(slider.min);
+                const max = Number(slider.max);
+                if (!Number.isFinite(value)) return 0;
+                return Math.min(max, Math.max(min, Math.round(value)));
+            };
+
+            const syncSlidersWithSelection = () => {
+                ensureSelection();
+                const blocks = getSelectedBlockElements();
+                if (!blocks.length) return;
+                const firstBlock = blocks[0];
+                const blockStyles = window.getComputedStyle(firstBlock);
+                const parent = firstBlock.parentElement;
+
+                const topValue = clampValue(parseFloat(firstBlock.style.marginTop || blockStyles.marginTop || '0'), sliderRefs.top.slider);
+                const bottomValue = clampValue(parseFloat(firstBlock.style.marginBottom || blockStyles.marginBottom || '0'), sliderRefs.bottom.slider);
+
+                let betweenValue = 0;
+                if (parent) {
+                    if (parent.dataset.customSpaceY) {
+                        betweenValue = clampValue(parseFloat(parent.dataset.customSpaceY), sliderRefs.between.slider);
+                    } else {
+                        const parentStyles = window.getComputedStyle(parent);
+                        const rowGap = parseFloat(parentStyles.rowGap || '0');
+                        const gap = parseFloat(parentStyles.gap || '0');
+                        const largestGap = Number.isFinite(rowGap) && rowGap > 0 ? rowGap : gap;
+                        if (Number.isFinite(largestGap)) {
+                            betweenValue = clampValue(largestGap, sliderRefs.between.slider);
+                        }
+                    }
+                }
+
+                sliderRefs.top.slider.value = String(topValue);
+                sliderRefs.bottom.slider.value = String(bottomValue);
+                sliderRefs.between.slider.value = String(betweenValue);
+                Object.values(sliderRefs).forEach(ref => ref.update());
+            };
+
+            const hidePanel = () => {
+                panel.classList.remove('visible');
+                toggleBtn.classList.remove('active');
+                spacingSelection = null;
+                savedEditorSelection = null;
+            };
+
+            toggleBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                const selection = window.getSelection();
+                if (!selection || selection.rangeCount === 0 || !notesEditor.contains(selection.anchorNode)) {
+                    hidePanel();
+                    return;
+                }
+                spacingSelection = selection.getRangeAt(0).cloneRange();
+                savedEditorSelection = spacingSelection.cloneRange();
+                const isVisible = panel.classList.contains('visible');
+                document.querySelectorAll('.color-submenu.visible, .symbol-dropdown-content.visible').forEach(el => {
+                    if (!panel.contains(el)) el.classList.remove('visible');
+                });
+                if (isVisible) {
+                    hidePanel();
+                } else {
+                    panel.classList.add('visible');
+                    toggleBtn.classList.add('active');
+                    syncSlidersWithSelection();
+                }
+            });
+
+            document.addEventListener('click', (evt) => {
+                if (!panel.contains(evt.target) && evt.target !== toggleBtn) {
+                    hidePanel();
+                }
+            });
+
+            wrapper.appendChild(toggleBtn);
+            wrapper.appendChild(panel);
+            return wrapper;
+        };
+
         const createColorPalette = (title, action, mainColors, extraColors, iconSVG) => {
             const group = document.createElement('div');
             group.className = 'color-palette-group';
@@ -4229,11 +4518,7 @@ ${exportTable.outerHTML}
         editorToolbar.appendChild(createSeparator());
 
         // Basic formatting
-        editorToolbar.appendChild(createButton('Negrita', '<b>B</b>', 'bold'));
-        editorToolbar.appendChild(createButton('Cursiva', '<i>I</i>', 'italic'));
-        editorToolbar.appendChild(createButton('Subrayado', '<u>U</u>', 'underline'));
         editorToolbar.appendChild(createButton('Tachado', '<s>S</s>', 'strikeThrough'));
-        editorToolbar.appendChild(createButton('Superíndice', 'X²', 'superscript'));
         editorToolbar.appendChild(createButton('Deshacer', '↺', null, null, undoAction));
         editorToolbar.appendChild(createButton('Rehacer', '↻', null, null, redoAction));
 
@@ -4278,7 +4563,7 @@ ${exportTable.outerHTML}
         
         const applyForeColor = (color) => document.execCommand('foreColor', false, color);
         const applyHiliteColor = (color) => document.execCommand('hiliteColor', false, color);
-        
+
         const applyLineHighlight = (color) => {
             let elements = getSelectedBlockElements();
             if (elements.length === 0 || (elements.length === 1 && !elements[0])) {
@@ -4336,14 +4621,300 @@ ${exportTable.outerHTML}
         const typeIcon = UI_ICON_STRINGS.type;
         const highlighterIcon = UI_ICON_STRINGS.highlighter;
 
-        const textPalette = createColorPalette('Color de Texto', applyForeColor, textColors, extraTextColors, typeIcon);
-        editorToolbar.appendChild(textPalette);
+        const tailwindSpacingPanel = createTailwindSpacingControl();
+        editorToolbar.appendChild(tailwindSpacingPanel);
 
-        const highlightPalette = createColorPalette('Color de Resaltado', applyHiliteColor, highlightColors, extraHighlightColors, highlighterIcon);
-        editorToolbar.appendChild(highlightPalette);
+        const initializeFloatingToolbar = () => {
+            if (!floatingToolbar) {
+                floatingToolbar = document.createElement('div');
+                floatingToolbar.id = 'floating-format-toolbar';
+                floatingToolbar.className = 'floating-format-toolbar';
+                document.body.appendChild(floatingToolbar);
+            }
 
-        const lineHighlightPalette = createColorPalette('Color de fondo de línea', applyLineHighlight, ['#FFFFFF'], extraHighlightColors.concat(highlightColors), highlighterIcon);
-        editorToolbar.appendChild(lineHighlightPalette);
+            floatingToolbar.innerHTML = '';
+
+            let floatingStyleMenu = document.getElementById('floating-style-menu');
+            if (!floatingStyleMenu) {
+                floatingStyleMenu = document.createElement('div');
+                floatingStyleMenu.id = 'floating-style-menu';
+                document.body.appendChild(floatingStyleMenu);
+            }
+            floatingStyleMenu.className = 'floating-style-menu preset-style-panel';
+            floatingStyleMenu.innerHTML = '';
+            floatingStyleMenu.style.display = 'none';
+
+            let floatingStyleControls = null;
+
+            const closeColorMenus = () => {
+                floatingToolbar.querySelectorAll('.floating-color-menu.visible').forEach(menu => menu.classList.remove('visible'));
+            };
+
+            const hideFloatingStyleMenu = () => {
+                if (!floatingStyleMenu) return;
+                floatingStyleMenu.classList.remove('visible');
+                floatingStyleMenu.style.display = 'none';
+                if (floatingStyleControls && typeof floatingStyleControls.closeAll === 'function') {
+                    floatingStyleControls.closeAll();
+                }
+            };
+
+            const hideFloatingMenus = () => {
+                closeColorMenus();
+                hideFloatingStyleMenu();
+                hidePillTextPopup();
+            };
+
+            const ensureFloatingStyleMenu = () => {
+                if (!floatingStyleControls) {
+                    floatingStyleControls = buildPresetStylePanel(floatingStyleMenu, (style, { closeAll }) => {
+                        if (savedEditorSelection) {
+                            const selection = window.getSelection();
+                            if (selection) {
+                                selection.removeAllRanges();
+                                selection.addRange(savedEditorSelection);
+                            }
+                        }
+                        withEditorSelection(() => applyPresetStyle(style));
+                        if (closeAll) closeAll();
+                        hideFloatingStyleMenu();
+                        savedEditorSelection = null;
+                        notesEditor.focus({ preventScroll: true });
+                    });
+                }
+            };
+
+            const executeCommand = (command, value = null) => {
+                withEditorSelection(() => document.execCommand(command, false, value));
+                hideFloatingMenus();
+                notesEditor.focus({ preventScroll: true });
+            };
+
+            const createFloatingButton = (title, html, handler) => {
+                const btn = document.createElement('button');
+                btn.type = 'button';
+                btn.className = 'toolbar-btn floating-toolbar-btn';
+                btn.title = title;
+                btn.innerHTML = html;
+                btn.addEventListener('mousedown', (e) => e.preventDefault());
+                btn.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    handler();
+                });
+                return btn;
+            };
+
+            const createFloatingPaletteControl = (title, iconSVG, mainColors, extraColors, applyAction) => {
+                const wrapper = document.createElement('div');
+                wrapper.className = 'floating-color-control';
+
+                const trigger = document.createElement('button');
+                trigger.type = 'button';
+                trigger.className = 'toolbar-btn floating-toolbar-btn';
+                trigger.innerHTML = iconSVG;
+                trigger.title = title;
+                trigger.addEventListener('mousedown', (e) => e.preventDefault());
+
+                const menu = document.createElement('div');
+                menu.className = 'floating-color-menu';
+
+                const createSwatch = (color) => {
+                    const swatch = document.createElement('button');
+                    swatch.type = 'button';
+                    swatch.className = 'color-swatch';
+                    if (color === 'transparent') {
+                        swatch.style.backgroundImage = 'linear-gradient(to top left, transparent calc(50% - 1px), red, transparent calc(50% + 1px))';
+                        swatch.style.backgroundColor = 'var(--bg-secondary)';
+                        swatch.title = 'Sin color';
+                    } else {
+                        swatch.style.backgroundColor = color;
+                        swatch.title = color;
+                    }
+                    swatch.addEventListener('mousedown', (e) => e.preventDefault());
+                    swatch.addEventListener('click', (e) => {
+                        e.preventDefault();
+                        if (savedEditorSelection) {
+                            const selection = window.getSelection();
+                            selection.removeAllRanges();
+                            selection.addRange(savedEditorSelection);
+                        }
+                        withEditorSelection(() => applyAction(color));
+                        hideFloatingMenus();
+                        savedEditorSelection = null;
+                        notesEditor.focus({ preventScroll: true });
+                    });
+                    return swatch;
+                };
+
+                mainColors.forEach(color => menu.appendChild(createSwatch(color)));
+
+                if (extraColors.length > 0) {
+                    const divider = document.createElement('div');
+                    divider.className = 'floating-color-divider';
+                    menu.appendChild(divider);
+                    extraColors.forEach(color => menu.appendChild(createSwatch(color)));
+                }
+
+                trigger.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    const selection = window.getSelection();
+                    if (selection && selection.rangeCount > 0) {
+                        savedEditorSelection = selection.getRangeAt(0).cloneRange();
+                    }
+                    const willShow = !menu.classList.contains('visible');
+                    closeColorMenus();
+                    hideFloatingStyleMenu();
+                    hidePillTextPopup();
+                    if (willShow) {
+                        menu.classList.add('visible');
+                    }
+                });
+
+                wrapper.appendChild(trigger);
+                wrapper.appendChild(menu);
+                return wrapper;
+            };
+
+            const floatingButtons = [
+                createFloatingButton('Negrita', '<b>B</b>', () => executeCommand('bold')),
+                createFloatingButton('Cursiva', '<i>I</i>', () => executeCommand('italic')),
+                createFloatingButton('Subrayado', '<u>U</u>', () => executeCommand('underline')),
+                createFloatingButton('Superíndice', 'X²', () => executeCommand('superscript'))
+            ];
+
+            floatingButtons.forEach(btn => floatingToolbar.appendChild(btn));
+
+            floatingToolbar.appendChild(createFloatingPaletteControl('Color de texto', UI_ICON_STRINGS.type, textColors, extraTextColors, applyForeColor));
+            floatingToolbar.appendChild(createFloatingPaletteControl('Color de resaltado', UI_ICON_STRINGS.highlighter, highlightColors, extraHighlightColors, applyHiliteColor));
+            floatingToolbar.appendChild(createFloatingPaletteControl('Color de fondo de línea', UI_ICON_STRINGS.highlighter, ['#FFFFFF'], extraHighlightColors.concat(highlightColors), applyLineHighlight));
+
+            const floatingStyleBtn = createFloatingButton('Estilos de texto', '🖌️', () => {
+                const selection = window.getSelection();
+                if (!selection || selection.rangeCount === 0 || !notesEditor.contains(selection.anchorNode)) {
+                    hideFloatingStyleMenu();
+                    return;
+                }
+                savedEditorSelection = selection.getRangeAt(0).cloneRange();
+                const willShow = !floatingStyleMenu.classList.contains('visible');
+                closeColorMenus();
+                hidePillTextPopup();
+                hideFloatingStyleMenu();
+                if (!willShow) return;
+                ensureFloatingStyleMenu();
+                if (floatingStyleControls && typeof floatingStyleControls.closeAll === 'function') {
+                    floatingStyleControls.closeAll();
+                }
+                floatingStyleMenu.style.display = 'block';
+                floatingStyleMenu.classList.add('visible');
+                const buttonRect = floatingStyleBtn.getBoundingClientRect();
+                const menuRect = floatingStyleMenu.getBoundingClientRect();
+                let top = window.scrollY + buttonRect.bottom + 8;
+                if (top + menuRect.height > window.scrollY + window.innerHeight - 8) {
+                    top = window.scrollY + buttonRect.top - menuRect.height - 8;
+                }
+                if (top < window.scrollY + 8) {
+                    top = window.scrollY + 8;
+                }
+                let left = window.scrollX + buttonRect.left + (buttonRect.width / 2) - (menuRect.width / 2);
+                const minLeft = window.scrollX + 8;
+                const maxLeft = window.scrollX + window.innerWidth - menuRect.width - 8;
+                if (left < minLeft) left = minLeft;
+                if (left > maxLeft) left = maxLeft;
+                floatingStyleMenu.style.top = `${top}px`;
+                floatingStyleMenu.style.left = `${left}px`;
+            });
+            floatingToolbar.appendChild(floatingStyleBtn);
+
+            const floatingPillBtn = createFloatingButton('Texto Píldora', '💊', () => {
+                const hasSelection = !!getActivePillRange() || capturePillSelection();
+                if (!hasSelection) return;
+                closeColorMenus();
+                hideFloatingStyleMenu();
+                setPillsText(null, floatingPillBtn);
+            });
+            floatingPillBtn.addEventListener('mousedown', (e) => {
+                e.preventDefault();
+                capturePillSelection();
+            });
+            floatingToolbar.appendChild(floatingPillBtn);
+
+            const hideFloatingToolbar = () => {
+                if (!floatingToolbar) return;
+                floatingToolbar.classList.remove('visible');
+                hideFloatingMenus();
+            };
+
+            dismissFloatingToolbar = () => {
+                hideFloatingToolbar();
+            };
+
+            const positionFloatingToolbar = () => {
+                if (!floatingToolbar) return;
+                const selection = window.getSelection();
+                if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+                    hideFloatingToolbar();
+                    return;
+                }
+                const range = selection.getRangeAt(0);
+                const rect = range.getBoundingClientRect();
+                if (!rect || (rect.width === 0 && rect.height === 0)) {
+                    hideFloatingToolbar();
+                    return;
+                }
+                const withinEditor = notesEditor.contains(range.commonAncestorContainer);
+                if (!withinEditor) {
+                    hideFloatingToolbar();
+                    return;
+                }
+
+                floatingToolbar.classList.add('visible');
+
+                const toolbarRect = floatingToolbar.getBoundingClientRect();
+                let top = window.scrollY + rect.top - toolbarRect.height - 8;
+                let left = window.scrollX + rect.left + (rect.width / 2) - (toolbarRect.width / 2);
+
+                if (top < window.scrollY + 8) {
+                    top = window.scrollY + rect.bottom + 8;
+                }
+
+                const maxLeft = window.scrollX + document.documentElement.clientWidth - toolbarRect.width - 8;
+                const minLeft = window.scrollX + 8;
+                if (left < minLeft) left = minLeft;
+                if (left > maxLeft) left = maxLeft;
+
+                floatingToolbar.style.top = `${top}px`;
+                floatingToolbar.style.left = `${left}px`;
+            };
+
+            if (!floatingToolbarInitialized) {
+                const handleSelectionChange = () => {
+                    requestAnimationFrame(positionFloatingToolbar);
+                };
+
+                document.addEventListener('selectionchange', handleSelectionChange);
+                notesEditor.addEventListener('mouseup', handleSelectionChange);
+                notesEditor.addEventListener('keyup', handleSelectionChange);
+                notesEditor.addEventListener('mouseleave', () => {
+                    setTimeout(() => {
+                        const selection = window.getSelection();
+                        if (!selection || selection.isCollapsed) hideFloatingToolbar();
+                    }, 120);
+                });
+                window.addEventListener('scroll', hideFloatingToolbar, true);
+                window.addEventListener('resize', hideFloatingToolbar);
+                notesModalContent.addEventListener('scroll', hideFloatingToolbar);
+                document.addEventListener('click', (e) => {
+                    if ((floatingToolbar && floatingToolbar.contains(e.target)) || (floatingStyleMenu && floatingStyleMenu.contains(e.target))) {
+                        return;
+                    }
+                    hideFloatingMenus();
+                });
+                floatingToolbarInitialized = true;
+            }
+        };
+
+        initializeFloatingToolbar();
 
         const convertListTag = (list, tagName) => {
             if (!list || list.tagName.toLowerCase() === tagName.toLowerCase()) return list;
@@ -4497,8 +5068,6 @@ ${exportTable.outerHTML}
             removeBullets();
         });
         editorToolbar.appendChild(removeBulletsBtn);
-
-        editorToolbar.appendChild(createPresetStyleDropdown());
 
         const inlineColorMenu = document.createElement('div');
         inlineColorMenu.className = 'inline-color-menu';
@@ -4814,110 +5383,55 @@ ${exportTable.outerHTML}
 
         // Popup to change existing preset styles
         const stylePopup = document.createElement('div');
-        stylePopup.className = 'styled-style-popup';
+        stylePopup.id = 'inline-style-popup';
+        stylePopup.className = 'preset-style-popup preset-style-panel inline-style-popup';
+        stylePopup.style.display = 'none';
         document.body.appendChild(stylePopup);
         let currentStyledSpan = null;
-
-        const renderStyledPopup = () => {
-            stylePopup.innerHTML = '';
-            const header = document.createElement('div');
-            header.className = 'styled-style-popup-header';
-            const title = document.createElement('span');
-            title.textContent = 'Cambiar estilo';
-            header.appendChild(title);
-            const closeBtn = document.createElement('button');
-            closeBtn.type = 'button';
-            closeBtn.className = 'styled-style-popup-close';
-            closeBtn.innerHTML = '&times;';
-            closeBtn.addEventListener('click', hideStylePopup);
-            header.appendChild(closeBtn);
-            stylePopup.appendChild(header);
-
-            const grid = document.createElement('div');
-            grid.className = 'styled-style-popup-grid';
-
-            PRESET_STYLE_GROUPS.forEach(group => {
-                const card = document.createElement('div');
-                card.className = 'styled-style-card';
-
-                const mainBtn = document.createElement('button');
-                mainBtn.type = 'button';
-                mainBtn.className = 'styled-style-main';
-                const mainPreview = document.createElement('span');
-                mainPreview.className = 'styled-style-preview';
-                mainPreview.setAttribute('style', group.style);
-                mainPreview.textContent = formatPresetLabel(group.label);
-                mainBtn.appendChild(mainPreview);
-                mainBtn.addEventListener('click', (event) => {
-                    event.preventDefault();
-                    if (!currentStyledSpan) return;
-                    applyPresetStyle(group.style, currentStyledSpan);
-                    hideStylePopup();
-                    notesEditor.focus({ preventScroll: true });
-                });
-                card.appendChild(mainBtn);
-
-                if (group.variants && group.variants.length) {
-                    const variantsRow = document.createElement('div');
-                    variantsRow.className = 'styled-style-variants';
-                    group.variants.forEach(variant => {
-                        const variantBtn = document.createElement('button');
-                        variantBtn.type = 'button';
-                        variantBtn.className = 'styled-style-variant-btn';
-                        const variantPreview = document.createElement('span');
-                        variantPreview.className = 'styled-style-preview';
-                        variantPreview.setAttribute('style', variant.style);
-                        variantPreview.textContent = formatPresetLabel(variant.label);
-                        variantBtn.appendChild(variantPreview);
-                        const variantName = document.createElement('span');
-                        variantName.className = 'styled-style-variant-label';
-                        const labelText = variant.label.replace(`${group.label} `, '').trim();
-                        variantName.textContent = labelText || 'Variante';
-                        variantBtn.appendChild(variantName);
-                        variantBtn.addEventListener('click', (event) => {
-                            event.preventDefault();
-                            if (!currentStyledSpan) return;
-                            applyPresetStyle(variant.style, currentStyledSpan);
-                            hideStylePopup();
-                            notesEditor.focus({ preventScroll: true });
-                        });
-                        variantsRow.appendChild(variantBtn);
-                    });
-                    card.appendChild(variantsRow);
-                }
-
-                grid.appendChild(card);
-            });
-
-            stylePopup.appendChild(grid);
-        };
+        let inlineStyleControls = null;
 
         const hideStylePopup = () => {
             stylePopup.classList.remove('visible');
+            stylePopup.style.display = 'none';
             currentStyledSpan = null;
+            if (inlineStyleControls && typeof inlineStyleControls.closeAll === 'function') {
+                inlineStyleControls.closeAll();
+            }
+        };
+
+        const ensureInlineStylePanel = () => {
+            if (inlineStyleControls) return;
+            inlineStyleControls = buildPresetStylePanel(stylePopup, (style, { closeAll }) => {
+                if (!currentStyledSpan) return;
+                applyPresetStyle(style, currentStyledSpan);
+                if (closeAll) closeAll();
+                hideStylePopup();
+                notesEditor.focus({ preventScroll: true });
+            });
         };
 
         const showStylePopup = (span) => {
             currentStyledSpan = span;
-            renderStyledPopup();
+            ensureInlineStylePanel();
+            stylePopup.style.display = 'flex';
             stylePopup.classList.add('visible');
             requestAnimationFrame(() => {
                 if (!currentStyledSpan) return;
                 const editorRect = notesEditor.getBoundingClientRect();
-                const desiredWidth = Math.min(560, Math.max(320, editorRect.width - 16));
+                const desiredWidth = Math.min(420, Math.max(240, editorRect.width - 24));
                 stylePopup.style.maxWidth = `${desiredWidth}px`;
                 const spanRect = span.getBoundingClientRect();
                 const popupRect = stylePopup.getBoundingClientRect();
-                let top = spanRect.bottom + window.scrollY + 8;
-                if (top + popupRect.height > window.scrollY + window.innerHeight - 8) {
-                    top = spanRect.top + window.scrollY - popupRect.height - 8;
+                let top = spanRect.bottom + window.scrollY + 6;
+                if (top + popupRect.height > window.scrollY + window.innerHeight - 6) {
+                    top = spanRect.top + window.scrollY - popupRect.height - 6;
                 }
                 let left = spanRect.left + window.scrollX;
-                if (left + popupRect.width > window.scrollX + window.innerWidth - 8) {
-                    left = Math.max(window.scrollX + 8, window.scrollX + window.innerWidth - popupRect.width - 8);
+                if (left + popupRect.width > window.scrollX + window.innerWidth - 6) {
+                    left = Math.max(window.scrollX + 6, window.scrollX + window.innerWidth - popupRect.width - 6);
                 }
-                stylePopup.style.top = `${Math.max(window.scrollY + 8, top)}px`;
-                stylePopup.style.left = `${Math.max(window.scrollX + 8, left)}px`;
+                stylePopup.style.top = `${Math.max(window.scrollY + 6, top)}px`;
+                stylePopup.style.left = `${Math.max(window.scrollX + 6, left)}px`;
             });
         };
 
@@ -4959,10 +5473,52 @@ ${exportTable.outerHTML}
         pillTextPopup.className = 'preset-style-popup';
         document.body.appendChild(pillTextPopup);
         let currentPillSpan = null;
+        let pillSelectionRange = null;
+
+        const isValidPillRange = (range) => {
+            return !!(range && !range.collapsed && notesEditor.contains(range.commonAncestorContainer));
+        };
+
+        const rememberPillSelection = (range) => {
+            if (!isValidPillRange(range)) return false;
+            pillSelectionRange = range.cloneRange();
+            savedEditorSelection = pillSelectionRange.cloneRange();
+            return true;
+        };
+
+        const getActivePillRange = () => {
+            if (isValidPillRange(pillSelectionRange)) return pillSelectionRange.cloneRange();
+            if (isValidPillRange(savedEditorSelection)) return savedEditorSelection.cloneRange();
+            const selection = window.getSelection();
+            if (selection && selection.rangeCount > 0) {
+                const range = selection.getRangeAt(0);
+                if (isValidPillRange(range)) return range.cloneRange();
+            }
+            return null;
+        };
 
         const hidePillTextPopup = () => {
             pillTextPopup.style.display = 'none';
             currentPillSpan = null;
+            pillSelectionRange = null;
+        };
+
+        function capturePillSelection() {
+            const selection = window.getSelection();
+            if (!selection || selection.rangeCount === 0) return false;
+            const range = selection.getRangeAt(0);
+            return rememberPillSelection(range);
+        }
+
+        const restorePillSelection = () => {
+            const activeRange = getActivePillRange();
+            if (!activeRange) return null;
+            const selection = window.getSelection();
+            if (!selection) return null;
+            selection.removeAllRanges();
+            selection.addRange(activeRange);
+            rememberPillSelection(selection.getRangeAt(0));
+            return selection.getRangeAt(0);
         };
 
         const applyPillTextStyle = (colors, existingSpan = null) => {
@@ -4970,32 +5526,44 @@ ${exportTable.outerHTML}
             if (existingSpan) {
                 existingSpan.style.cssText = css;
                 existingSpan.dataset.pillText = colors.join('|');
+                recordHistory();
+                notesEditor.dispatchEvent(new Event('input', { bubbles: true }));
                 return;
             }
-            if (savedEditorSelection) {
-                const selection = window.getSelection();
-                selection.removeAllRanges();
-                selection.addRange(savedEditorSelection);
+            const range = restorePillSelection();
+            if (!range || range.collapsed) {
+                pillSelectionRange = null;
+                savedEditorSelection = null;
+                return;
             }
-            const sel = window.getSelection();
-            if (!sel || !sel.rangeCount || sel.isCollapsed) return;
-            const range = sel.getRangeAt(0);
+            const fallbackText = range.toString();
+            const extracted = range.extractContents();
             const span = document.createElement('span');
             span.style.cssText = css;
             span.dataset.pillText = colors.join('|');
-            span.textContent = range.toString();
-            range.deleteContents();
+            if (!extracted || extracted.childNodes.length === 0) {
+                span.textContent = fallbackText;
+            } else {
+                span.appendChild(extracted);
+            }
             range.insertNode(span);
             const newRange = document.createRange();
             newRange.setStartAfter(span);
             newRange.collapse(true);
-            sel.removeAllRanges();
-            sel.addRange(newRange);
+            const selection = window.getSelection();
+            if (selection) {
+                selection.removeAllRanges();
+                selection.addRange(newRange);
+            }
+            pillSelectionRange = null;
             savedEditorSelection = null;
+            recordHistory();
+            notesEditor.dispatchEvent(new Event('input', { bubbles: true }));
         };
 
         const showPillTextPopup = (span = null, anchor = null) => {
-            const sample = span ? span.textContent : (savedEditorSelection ? savedEditorSelection.toString() : window.getSelection().toString());
+            const activeRange = getActivePillRange();
+            const sample = span ? span.textContent : (activeRange ? activeRange.toString() : window.getSelection().toString());
             pillTextPopup.innerHTML = '';
             PILL_TEXT_STYLES.forEach(colors => {
                 const b = document.createElement('button');
@@ -5012,8 +5580,8 @@ ${exportTable.outerHTML}
             let rect;
             if (span) {
                 rect = span.getBoundingClientRect();
-            } else if (savedEditorSelection) {
-                rect = savedEditorSelection.getBoundingClientRect();
+            } else if (activeRange) {
+                rect = activeRange.getBoundingClientRect();
             } else if (anchor) {
                 rect = anchor.getBoundingClientRect();
             } else {
@@ -5027,44 +5595,34 @@ ${exportTable.outerHTML}
         };
 
         const setPillsText = (span = null, anchor = null) => {
-            currentPillSpan = span;
-            showPillTextPopup(span, anchor);
-        };
-
-        const pillTextBtn = createButton('Texto Píldora', '💊', null, null, null);
-        pillTextBtn.addEventListener('mousedown', (e) => {
-            e.preventDefault();
-            const selection = window.getSelection();
-            if (selection.rangeCount > 0 && notesEditor.contains(selection.anchorNode)) {
-                savedEditorSelection = selection.getRangeAt(0).cloneRange();
+            if (!span) {
+                const activeRange = getActivePillRange();
+                if (!activeRange || !rememberPillSelection(activeRange)) {
+                    hidePillTextPopup();
+                    return;
+                }
+                currentPillSpan = null;
             } else {
+                currentPillSpan = span;
+                pillSelectionRange = null;
                 savedEditorSelection = null;
             }
-        });
-        pillTextBtn.addEventListener('click', (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            if (savedEditorSelection && !savedEditorSelection.collapsed) {
-                const sel = window.getSelection();
-                sel.removeAllRanges();
-                sel.addRange(savedEditorSelection);
-                setPillsText(null, pillTextBtn);
-            }
-        });
-        editorToolbar.appendChild(pillTextBtn);
+            showPillTextPopup(span, anchor);
+        };
 
         notesEditor.addEventListener('click', (e) => {
             const span = e.target.closest('span[data-pill-text]');
             if (span) {
                 e.stopPropagation();
-                savedEditorSelection = null;
                 setPillsText(span);
             } else if (!e.target.closest('.preset-style-popup')) {
                 hidePillTextPopup();
             }
         });
         document.addEventListener('click', (e) => {
-            if (!pillTextPopup.contains(e.target)) hidePillTextPopup();
+            if (pillTextPopup.contains(e.target)) return;
+            if (e.target.closest('#floating-format-toolbar')) return;
+            hidePillTextPopup();
         });
         notesEditor.addEventListener('keydown', (e) => {
             if (e.key === 'Enter') {
@@ -5227,6 +5785,40 @@ ${exportTable.outerHTML}
                 table.style.marginBottom = `${bottomValue}px`;
                 table.dataset.tableMarginBottom = `${bottomValue}`;
             }
+        };
+
+        const toggleHeaderRow = (table) => {
+            if (!table || !table.rows.length) return false;
+            const firstRow = table.rows[0];
+            const isHeader = Array.from(firstRow.cells).every(cell => cell.tagName === 'TH');
+            Array.from(firstRow.cells).forEach(cell => convertCellTag(cell, isHeader ? 'td' : 'th'));
+            return !isHeader;
+        };
+
+        const toggleTableStriping = (table) => {
+            if (!table) return false;
+            const willActivate = !table.classList.contains('table-striped');
+            table.classList.toggle('table-striped', willActivate);
+            if (willActivate) {
+                table.dataset.striped = 'true';
+            } else {
+                delete table.dataset.striped;
+            }
+            return willActivate;
+        };
+
+        const autoFitTableColumns = (table) => {
+            if (!table || !table.rows.length) return;
+            const firstRow = table.rows[0];
+            const columns = firstRow ? firstRow.cells.length : 0;
+            if (!columns) return;
+            const widthPercent = 100 / columns;
+            Array.from(table.rows).forEach(row => {
+                Array.from(row.cells).forEach(cell => {
+                    cell.style.width = `${widthPercent}%`;
+                });
+            });
+            table.style.width = '100%';
         };
 
         const ensureSpacingState = (table) => {
@@ -5395,15 +5987,33 @@ ${exportTable.outerHTML}
             currentTable = table;
             tableMenu.innerHTML = '';
 
+            const headerBar = document.createElement('div');
+            headerBar.className = 'table-menu-header';
+
+            const summary = document.createElement('span');
+            summary.className = 'table-menu-summary';
+            const totalRows = table.rows.length;
+            const totalCols = table.rows[0] ? table.rows[0].cells.length : 0;
+            summary.textContent = `${totalRows || 0}×${totalCols || 0} celdas`;
+            headerBar.appendChild(summary);
+
             const resizeBtn = document.createElement('button');
-            resizeBtn.className = 'toolbar-btn';
-            resizeBtn.innerHTML = '↔️ Ajustar tamaño';
+            resizeBtn.type = 'button';
+            resizeBtn.className = 'toolbar-btn table-header-btn';
+            resizeBtn.innerHTML = '<span class="table-menu-icon">↔️</span><span class="table-menu-label">Tamaño</span>';
+            resizeBtn.title = 'Activar controles de tamaño';
             resizeBtn.addEventListener('click', () => {
                 tableEditMode = true;
                 editingTable = table;
+                if (!table.querySelector('.table-resize-handle')) {
+                    initTableResize(table);
+                }
+                table.classList.add('selected');
                 hideTableMenu();
             });
-            tableMenu.appendChild(resizeBtn);
+            headerBar.appendChild(resizeBtn);
+
+            tableMenu.appendChild(headerBar);
 
             const tabsBar = document.createElement('div');
             tabsBar.className = 'table-menu-tabs';
@@ -5417,41 +6027,80 @@ ${exportTable.outerHTML}
 
             const buildEditTab = () => {
                 tabContent.innerHTML = '';
-                const layout = document.createElement('div');
-                layout.className = 'table-edit-layout';
-                const createGroup = (title) => {
-                    const group = document.createElement('div');
-                    group.className = 'table-edit-group';
-                    const heading = document.createElement('div');
-                    heading.className = 'table-edit-group-title';
-                    heading.textContent = title;
-                    group.appendChild(heading);
-                    return group;
+                const quickGrid = document.createElement('div');
+                quickGrid.className = 'table-quick-grid';
+                const actionConfigs = [
+                    { icon: '⬆️', label: 'Fila ↑', onClick: () => addRow(table, rIndex) },
+                    { icon: '⬇️', label: 'Fila ↓', onClick: () => addRow(table, rIndex + 1) },
+                    { icon: '🗑️', label: 'Fila -', onClick: () => deleteRow(table, rIndex) },
+                    { icon: '⬅️', label: 'Col ←', onClick: () => addColumn(table, cIndex) },
+                    { icon: '➡️', label: 'Col →', onClick: () => addColumn(table, cIndex + 1) },
+                    { icon: '🧹', label: 'Col -', onClick: () => deleteColumn(table, cIndex) },
+                    {
+                        icon: '🔎',
+                        label: 'Ver col',
+                        onClick: () => selectColumn(table, cIndex),
+                        persistent: true
+                    },
+                    {
+                        icon: '🔠',
+                        label: 'Cabecera',
+                        onClick: () => toggleHeaderRow(table),
+                        state: () => {
+                            const firstRow = table.rows[0];
+                            return firstRow ? Array.from(firstRow.cells).every(cell => cell.tagName === 'TH') : false;
+                        },
+                        persistent: true
+                    },
+                    {
+                        icon: '🦓',
+                        label: 'Cebra',
+                        onClick: () => toggleTableStriping(table),
+                        state: () => table.classList.contains('table-striped'),
+                        persistent: true
+                    },
+                    {
+                        icon: '📐',
+                        label: 'Auto ancho',
+                        onClick: () => autoFitTableColumns(table)
+                    }
+                ];
+
+                const quickButtons = [];
+                const updateQuickActionStates = () => {
+                    quickButtons.forEach(({ action, button }) => {
+                        if (typeof action.state === 'function') {
+                            const active = !!action.state();
+                            button.classList.toggle('active', active);
+                            button.setAttribute('aria-pressed', active ? 'true' : 'false');
+                        }
+                    });
                 };
-                const createActionButton = (label, icon, handler) => {
+
+                actionConfigs.forEach(action => {
                     const btn = document.createElement('button');
                     btn.type = 'button';
-                    btn.className = 'toolbar-btn table-edit-btn';
-                    btn.innerHTML = `<span class="table-edit-icon">${icon}</span><span>${label}</span>`;
+                    btn.className = 'toolbar-btn table-quick-action';
+                    btn.innerHTML = `<span class="table-quick-icon">${action.icon}</span><span class="table-quick-label">${action.label}</span>`;
                     btn.addEventListener('click', () => {
-                        handler();
-                        hideTableMenu();
+                        action.onClick();
+                        updateQuickActionStates();
                         notesEditor.focus({ preventScroll: true });
+                        if (!action.persistent) {
+                            hideTableMenu();
+                        }
                     });
-                    return btn;
-                };
-                const rowsGroup = createGroup('Filas');
-                rowsGroup.appendChild(createActionButton('Agregar arriba', '⬆️', () => addRow(table, rIndex)));
-                rowsGroup.appendChild(createActionButton('Agregar abajo', '⬇️', () => addRow(table, rIndex + 1)));
-                rowsGroup.appendChild(createActionButton('Eliminar fila', '🗑️', () => deleteRow(table, rIndex)));
-                const colsGroup = createGroup('Columnas');
-                colsGroup.appendChild(createActionButton('Añadir a la izquierda', '⬅️', () => addColumn(table, cIndex)));
-                colsGroup.appendChild(createActionButton('Añadir a la derecha', '➡️', () => addColumn(table, cIndex + 1)));
-                colsGroup.appendChild(createActionButton('Eliminar columna', '🗑️', () => deleteColumn(table, cIndex)));
-                colsGroup.appendChild(createActionButton('Seleccionar columna', '🔎', () => selectColumn(table, cIndex)));
-                layout.appendChild(rowsGroup);
-                layout.appendChild(colsGroup);
-                tabContent.appendChild(layout);
+                    quickGrid.appendChild(btn);
+                    quickButtons.push({ action, button: btn });
+                });
+
+                tabContent.appendChild(quickGrid);
+                updateQuickActionStates();
+
+                const helper = document.createElement('p');
+                helper.className = 'table-menu-hint';
+                helper.textContent = 'Tip: selecciona una columna y aplica estilos sin cerrar este panel.';
+                tabContent.appendChild(helper);
             };
 
             const HEADER_COLORS = [
@@ -5790,7 +6439,7 @@ ${exportTable.outerHTML}
             const editorWidth = Math.max(280, editorRect.width - 16);
             const viewportLimit = Math.max(280, window.innerWidth - 32);
             const maxWidth = Math.min(editorWidth, viewportLimit);
-            const preferredWidth = Math.max(420, Math.min(maxWidth, 640));
+            const preferredWidth = Math.max(340, Math.min(maxWidth, 520));
             const targetWidth = Math.min(preferredWidth, maxWidth);
             tableMenu.style.maxWidth = `${maxWidth}px`;
             tableMenu.style.width = `${targetWidth}px`;
@@ -5807,7 +6456,7 @@ ${exportTable.outerHTML}
             tableMenu.style.left = `${left}px`;
             tableMenu.style.zIndex = 10001;
         };
-        notesEditor.addEventListener('click', (e) => {
+        notesEditor.addEventListener('dblclick', (e) => {
             if (tableEditMode) return;
             const cell = e.target.closest('td, th');
             const table = e.target.closest('table');
@@ -5825,8 +6474,19 @@ ${exportTable.outerHTML}
         });
         document.addEventListener('click', (e) => {
             if (tableEditMode && editingTable && !editingTable.contains(e.target)) {
+                editingTable.classList.remove('selected');
                 tableEditMode = false;
                 editingTable = null;
+            }
+        });
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && tableEditMode) {
+                if (editingTable) {
+                    editingTable.classList.remove('selected');
+                }
+                tableEditMode = false;
+                editingTable = null;
+                hideTableMenu();
             }
         });
         document.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- add dedicated helpers to validate, remember, and restore pill-text ranges before opening the preset menu
- update the floating toolbar pill button and popup positioning to reuse the saved range and keep the selector open when invoked from the floating toolbar

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8b8d57dcc832c9981637c0afde4ff