### PR TITLE
Add table export downloads and image editing tools

### DIFF
--- a/image-tools.js
+++ b/image-tools.js
@@ -112,12 +112,17 @@ export function setupImageTools(editor, toolbar) {
       <button data-align="center">◎</button>
       <button data-align="right">◨</button>
     </div>
-    <button class="title-btn">Título</button>
+    <div class="extras-group">
+      <button class="title-btn">Título</button>
+      <button class="edit-image-btn">Editar</button>
+    </div>
   `;
   document.body.appendChild(menu);
 
   const micromoveStep = 4;
   let activeImg = null;
+
+  const imageEditor = createImageEditor();
 
   const sizeGroup = menu.querySelector('.size-group');
   const minusBtn = document.createElement('button');
@@ -164,6 +169,8 @@ export function setupImageTools(editor, toolbar) {
       applyAlignment(alignBtn.dataset.align);
     } else if (e.target.classList.contains('title-btn') && activeImg) {
       openTitleEditor();
+    } else if (e.target.classList.contains('edit-image-btn') && activeImg) {
+      imageEditor.open(activeImg);
     }
   });
 
@@ -249,6 +256,400 @@ export function setupImageTools(editor, toolbar) {
     if (caption && caption.classList.contains('image-caption')) {
       caption.style.width = activeImg.offsetWidth + 'px';
     }
+  }
+
+  function createImageEditor() {
+    const modal = document.createElement('div');
+    modal.className = 'image-editor-modal hidden';
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-modal', 'true');
+    modal.setAttribute('aria-labelledby', 'image-editor-title');
+    modal.innerHTML = `
+      <div class="image-editor-dialog">
+        <header class="image-editor-header">
+          <h2 id="image-editor-title">Editar imagen</h2>
+          <button type="button" class="image-editor-close" aria-label="Cerrar">×</button>
+        </header>
+        <div class="image-editor-body">
+          <div class="image-editor-preview">
+            <canvas></canvas>
+            <div class="image-editor-loading" role="status">Cargando imagen…</div>
+            <p class="image-editor-size">—</p>
+          </div>
+          <div class="image-editor-controls">
+            <section class="image-editor-section">
+              <h3>Recorte</h3>
+              <div class="image-editor-field">
+                <label>Superior
+                  <input type="range" name="crop-top" min="0" value="0">
+                  <output data-for="crop-top">0 px</output>
+                </label>
+              </div>
+              <div class="image-editor-field">
+                <label>Inferior
+                  <input type="range" name="crop-bottom" min="0" value="0">
+                  <output data-for="crop-bottom">0 px</output>
+                </label>
+              </div>
+              <div class="image-editor-field">
+                <label>Izquierda
+                  <input type="range" name="crop-left" min="0" value="0">
+                  <output data-for="crop-left">0 px</output>
+                </label>
+              </div>
+              <div class="image-editor-field">
+                <label>Derecha
+                  <input type="range" name="crop-right" min="0" value="0">
+                  <output data-for="crop-right">0 px</output>
+                </label>
+              </div>
+            </section>
+            <section class="image-editor-section">
+              <h3>Texto superpuesto</h3>
+              <div class="image-editor-field">
+                <label>Contenido
+                  <input type="text" name="overlay-text" placeholder="Añade un texto opcional">
+                </label>
+              </div>
+              <div class="image-editor-field image-editor-field--split">
+                <label>Tamaño
+                  <input type="range" name="overlay-size" min="12" max="96" value="28">
+                  <output data-for="overlay-size">28 px</output>
+                </label>
+                <label>Color
+                  <input type="color" name="overlay-color" value="#111827">
+                </label>
+              </div>
+              <div class="image-editor-field image-editor-field--split">
+                <label>Fondo
+                  <input type="color" name="overlay-bg" value="#ffffff">
+                </label>
+                <label>Opacidad del fondo
+                  <input type="range" name="overlay-bg-opacity" min="0" max="0.95" step="0.05" value="0">
+                  <output data-for="overlay-bg-opacity">0%</output>
+                </label>
+              </div>
+              <div class="image-editor-field image-editor-field--split">
+                <label>Posición X
+                  <input type="range" name="overlay-x" min="0" max="100" value="6">
+                  <output data-for="overlay-x">6%</output>
+                </label>
+                <label>Posición Y
+                  <input type="range" name="overlay-y" min="0" max="100" value="6">
+                  <output data-for="overlay-y">6%</output>
+                </label>
+              </div>
+            </section>
+          </div>
+        </div>
+        <footer class="image-editor-footer">
+          <button type="button" class="cancel-btn">Cancelar</button>
+          <button type="button" class="apply-btn">Aplicar</button>
+        </footer>
+      </div>
+    `;
+    document.body.appendChild(modal);
+
+    const canvas = modal.querySelector('canvas');
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      console.warn('El editor de imágenes no pudo inicializar su lienzo.');
+      return {
+        open() {},
+        close() {}
+      };
+    }
+    const loadingIndicator = modal.querySelector('.image-editor-loading');
+    const sizeLabel = modal.querySelector('.image-editor-size');
+    const closeBtn = modal.querySelector('.image-editor-close');
+    const cancelBtn = modal.querySelector('.cancel-btn');
+    const applyBtn = modal.querySelector('.apply-btn');
+    const textInput = modal.querySelector('input[name="overlay-text"]');
+    const textSizeInput = modal.querySelector('input[name="overlay-size"]');
+    const textColorInput = modal.querySelector('input[name="overlay-color"]');
+    const textBgInput = modal.querySelector('input[name="overlay-bg"]');
+    const textBgOpacityInput = modal.querySelector('input[name="overlay-bg-opacity"]');
+    const textXInput = modal.querySelector('input[name="overlay-x"]');
+    const textYInput = modal.querySelector('input[name="overlay-y"]');
+    const cropInputs = {
+      top: modal.querySelector('input[name="crop-top"]'),
+      bottom: modal.querySelector('input[name="crop-bottom"]'),
+      left: modal.querySelector('input[name="crop-left"]'),
+      right: modal.querySelector('input[name="crop-right"]')
+    };
+    const cropOutputs = {
+      top: modal.querySelector('output[data-for="crop-top"]'),
+      bottom: modal.querySelector('output[data-for="crop-bottom"]'),
+      left: modal.querySelector('output[data-for="crop-left"]'),
+      right: modal.querySelector('output[data-for="crop-right"]')
+    };
+    const overlayOutputs = {
+      size: modal.querySelector('output[data-for="overlay-size"]'),
+      bgOpacity: modal.querySelector('output[data-for="overlay-bg-opacity"]'),
+      x: modal.querySelector('output[data-for="overlay-x"]'),
+      y: modal.querySelector('output[data-for="overlay-y"]')
+    };
+
+    const baseFontFamily = window.getComputedStyle(editor).fontFamily || 'sans-serif';
+
+    const state = {
+      target: null,
+      image: null,
+      naturalWidth: 0,
+      naturalHeight: 0,
+      crop: { top: 0, bottom: 0, left: 0, right: 0 },
+      returningFocus: null
+    };
+
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeEditor();
+      }
+    };
+
+    function openEditor(targetImage) {
+      if (!targetImage) return;
+      state.target = targetImage;
+      state.returningFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      modal.classList.remove('hidden');
+      document.body.classList.add('image-editor-open');
+      loadingIndicator.textContent = 'Cargando imagen…';
+      loadingIndicator.classList.remove('hidden');
+      canvas.classList.add('image-editor-canvas--hidden');
+      applyBtn.disabled = true;
+      textInput.value = '';
+      textSizeInput.value = '28';
+      textColorInput.value = '#111827';
+      textBgInput.value = '#ffffff';
+      textBgOpacityInput.value = '0';
+      textXInput.value = '6';
+      textYInput.value = '6';
+      overlayOutputs.size.textContent = '28 px';
+      overlayOutputs.bgOpacity.textContent = '0%';
+      overlayOutputs.x.textContent = '6%';
+      overlayOutputs.y.textContent = '6%';
+
+      const loader = new Image();
+      loader.decoding = 'async';
+      const expectedTarget = targetImage;
+      loader.onload = () => {
+        if (state.target !== expectedTarget) return;
+        state.image = loader;
+        state.naturalWidth = loader.naturalWidth || loader.width;
+        state.naturalHeight = loader.naturalHeight || loader.height;
+        state.crop = { top: 0, bottom: 0, left: 0, right: 0 };
+        updateCropInputs();
+        renderPreview();
+        loadingIndicator.classList.add('hidden');
+        canvas.classList.remove('image-editor-canvas--hidden');
+        applyBtn.disabled = false;
+        textInput.focus();
+      };
+      loader.onerror = () => {
+        if (state.target !== expectedTarget) return;
+        loadingIndicator.textContent = 'No se pudo cargar la imagen.';
+        applyBtn.disabled = true;
+      };
+      loader.src = targetImage.src;
+      document.addEventListener('keydown', onKeyDown, true);
+    }
+
+    function closeEditor() {
+      modal.classList.add('hidden');
+      document.body.classList.remove('image-editor-open');
+      document.removeEventListener('keydown', onKeyDown, true);
+      state.target = null;
+      if (state.returningFocus && state.returningFocus.focus) {
+        state.returningFocus.focus();
+      }
+      state.returningFocus = null;
+    }
+
+    function updateCropInputs() {
+      const maxVertical = Math.max(0, state.naturalHeight - 1);
+      const maxHorizontal = Math.max(0, state.naturalWidth - 1);
+      cropInputs.top.max = maxVertical;
+      cropInputs.bottom.max = maxVertical;
+      cropInputs.left.max = maxHorizontal;
+      cropInputs.right.max = maxHorizontal;
+      Object.keys(cropInputs).forEach(key => {
+        cropInputs[key].value = state.crop[key];
+        if (cropOutputs[key]) {
+          cropOutputs[key].textContent = `${state.crop[key]} px`;
+        }
+      });
+    }
+
+    function updateCropValue(edge, value) {
+      const numeric = Math.max(0, Math.round(Number(value) || 0));
+      state.crop[edge] = numeric;
+      if (state.crop.top + state.crop.bottom >= state.naturalHeight) {
+        if (edge === 'top') {
+          state.crop.top = Math.max(0, state.naturalHeight - state.crop.bottom - 1);
+        } else if (edge === 'bottom') {
+          state.crop.bottom = Math.max(0, state.naturalHeight - state.crop.top - 1);
+        }
+      }
+      if (state.crop.left + state.crop.right >= state.naturalWidth) {
+        if (edge === 'left') {
+          state.crop.left = Math.max(0, state.naturalWidth - state.crop.right - 1);
+        } else if (edge === 'right') {
+          state.crop.right = Math.max(0, state.naturalWidth - state.crop.left - 1);
+        }
+      }
+      if (cropInputs[edge]) {
+        cropInputs[edge].value = state.crop[edge];
+      }
+      if (cropOutputs[edge]) {
+        cropOutputs[edge].textContent = `${state.crop[edge]} px`;
+      }
+      renderPreview();
+    }
+
+    function renderPreview() {
+      if (!state.image || !ctx) return;
+      const width = Math.max(1, state.naturalWidth - state.crop.left - state.crop.right);
+      const height = Math.max(1, state.naturalHeight - state.crop.top - state.crop.bottom);
+      canvas.width = width;
+      canvas.height = height;
+      ctx.clearRect(0, 0, width, height);
+      ctx.drawImage(
+        state.image,
+        state.crop.left,
+        state.crop.top,
+        width,
+        height,
+        0,
+        0,
+        width,
+        height
+      );
+
+      const text = textInput.value.trim();
+      if (text) {
+        const fontSize = Math.max(8, Math.round(Number(textSizeInput.value) || 28));
+        const color = textColorInput.value || '#111827';
+        const bgColor = textBgInput.value || '#ffffff';
+        const bgOpacity = Math.min(0.95, Math.max(0, Number(textBgOpacityInput.value) || 0));
+        const xPercent = Math.min(100, Math.max(0, Number(textXInput.value) || 0));
+        const yPercent = Math.min(100, Math.max(0, Number(textYInput.value) || 0));
+        const textLines = text.split(/\r?\n/);
+        const lineHeight = Math.round(fontSize * 1.25);
+        ctx.font = `${fontSize}px ${baseFontFamily}`;
+        ctx.textBaseline = 'top';
+        ctx.fillStyle = color;
+        ctx.textAlign = 'left';
+
+        let maxLineWidth = 0;
+        textLines.forEach(line => {
+          const metrics = ctx.measureText(line);
+          maxLineWidth = Math.max(maxLineWidth, metrics.width);
+        });
+        const boxWidth = Math.ceil(maxLineWidth) + 16;
+        const boxHeight = textLines.length * lineHeight + 16;
+        const rawX = Math.round((width - 1) * (xPercent / 100));
+        const rawY = Math.round((height - 1) * (yPercent / 100));
+        const maxX = Math.max(0, width - boxWidth);
+        const maxY = Math.max(0, height - boxHeight);
+        const clampedX = Math.min(maxX, Math.max(0, rawX));
+        const clampedY = Math.min(maxY, Math.max(0, rawY));
+
+        if (bgOpacity > 0) {
+          ctx.save();
+          ctx.fillStyle = hexToRgba(bgColor, bgOpacity);
+          ctx.fillRect(clampedX, clampedY, Math.min(boxWidth, width), Math.min(boxHeight, height));
+          ctx.restore();
+        }
+
+        ctx.fillStyle = color;
+        textLines.forEach((line, index) => {
+          const textX = clampedX + 8;
+          const textY = clampedY + 8 + index * lineHeight;
+          ctx.fillText(line, textX, textY);
+        });
+      }
+
+      sizeLabel.textContent = `${width} × ${height}px`;
+    }
+
+    function applyChanges() {
+      if (!state.target) return;
+      const previousWidth = state.target.style.width;
+      const previousHeight = state.target.style.height;
+      const dataUrl = canvas.toDataURL('image/png');
+      const target = state.target;
+      const refreshSelection = () => {
+        target.style.width = previousWidth;
+        target.style.height = previousHeight;
+        syncCaptionWidth();
+        positionUI();
+      };
+      target.addEventListener('load', refreshSelection, { once: true });
+      target.src = dataUrl;
+      target.dataset.edited = 'true';
+      closeEditor();
+      if (!target.complete) {
+        return;
+      }
+      refreshSelection();
+    }
+
+    function hexToRgba(hex, alpha) {
+      let normalized = (hex || '').trim().replace('#', '');
+      if (normalized.length === 3) {
+        normalized = normalized.split('').map(ch => ch + ch).join('');
+      }
+      if (normalized.length !== 6) {
+        return `rgba(255,255,255,${alpha})`;
+      }
+      const r = parseInt(normalized.substring(0, 2), 16);
+      const g = parseInt(normalized.substring(2, 4), 16);
+      const b = parseInt(normalized.substring(4, 6), 16);
+      return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    }
+
+    Object.entries(cropInputs).forEach(([edge, input]) => {
+      input.addEventListener('input', (event) => updateCropValue(edge, event.target.value));
+    });
+
+    textInput.addEventListener('input', renderPreview);
+    textSizeInput.addEventListener('input', (event) => {
+      const value = Math.max(8, Math.round(Number(event.target.value) || 28));
+      overlayOutputs.size.textContent = `${value} px`;
+      renderPreview();
+    });
+    textColorInput.addEventListener('input', renderPreview);
+    textBgInput.addEventListener('input', renderPreview);
+    textBgOpacityInput.addEventListener('input', (event) => {
+      const value = Math.min(0.95, Math.max(0, Number(event.target.value) || 0));
+      overlayOutputs.bgOpacity.textContent = `${Math.round(value * 100)}%`;
+      renderPreview();
+    });
+    textXInput.addEventListener('input', (event) => {
+      const value = Math.min(100, Math.max(0, Number(event.target.value) || 0));
+      overlayOutputs.x.textContent = `${Math.round(value)}%`;
+      renderPreview();
+    });
+    textYInput.addEventListener('input', (event) => {
+      const value = Math.min(100, Math.max(0, Number(event.target.value) || 0));
+      overlayOutputs.y.textContent = `${Math.round(value)}%`;
+      renderPreview();
+    });
+
+    closeBtn.addEventListener('click', closeEditor);
+    cancelBtn.addEventListener('click', closeEditor);
+    modal.addEventListener('click', (event) => {
+      if (event.target === modal) {
+        closeEditor();
+      }
+    });
+    applyBtn.addEventListener('click', applyChanges);
+
+    return {
+      open: openEditor,
+      close: closeEditor
+    };
   }
 
   editor.addEventListener('click', e => {

--- a/index.css
+++ b/index.css
@@ -1663,6 +1663,38 @@ table.resizable-table th {
     background: var(--bg-tertiary);
     font-weight: bold;
 }
+.table-export-section {
+    border-top: 1px solid var(--border-color, #d1d5db);
+    padding-top: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+.table-export-title {
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: var(--text-secondary, #4b5563);
+}
+.table-export-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+.table-export-btn {
+    flex: 1;
+    min-width: 120px;
+    font-weight: 600;
+}
+.table-export-btn:disabled {
+    opacity: 0.6;
+    cursor: progress;
+}
+.table-export-status {
+    font-size: 0.7rem;
+    color: var(--text-secondary, #4b5563);
+}
 .table-menu-header {
     display: flex;
     align-items: center;
@@ -2261,6 +2293,17 @@ table.table-striped tr:first-child td {
   cursor: pointer;
   border-radius: 3px;
 }
+.image-menu .extras-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding-left: 6px;
+  margin-left: 4px;
+  border-left: 1px solid var(--border-color);
+}
+.image-menu .extras-group button {
+  min-width: 52px;
+}
 
 .image-menu .micro-group {
   display: inline-flex;
@@ -2302,6 +2345,196 @@ table.table-striped tr:first-child td {
   padding: 2px 4px;
   margin-top: 4px;
   display: block;
+}
+body.image-editor-open {
+  overflow: hidden;
+}
+.image-editor-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: rgba(15, 23, 42, 0.55);
+  z-index: 10005;
+}
+.image-editor-modal.hidden {
+  display: none;
+}
+.image-editor-dialog {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  width: min(940px, 96vw);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  border-radius: 12px;
+  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.28);
+  overflow: hidden;
+}
+.image-editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border-color);
+}
+.image-editor-header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+.image-editor-close {
+  border: none;
+  background: none;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--text-secondary);
+}
+.image-editor-body {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+.image-editor-preview {
+  flex: 1.25;
+  background: var(--bg-tertiary);
+  border: 1px dashed var(--border-color);
+  border-radius: 10px;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  min-height: 260px;
+  position: relative;
+}
+.image-editor-preview canvas {
+  max-width: 100%;
+  height: auto;
+  border-radius: 6px;
+  background: #fff;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.2);
+}
+.image-editor-canvas--hidden {
+  display: none;
+}
+.image-editor-loading {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+.image-editor-loading.hidden {
+  display: none;
+}
+.image-editor-size {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  margin: 0;
+}
+.image-editor-controls {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+.image-editor-section {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+}
+.image-editor-section h3 {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.image-editor-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.82rem;
+}
+.image-editor-field label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+.image-editor-field input[type="text"] {
+  padding: 0.45rem 0.5rem;
+  border-radius: 6px;
+  border: 1px solid var(--border-color);
+  font-size: 0.85rem;
+}
+.image-editor-field input[type="color"] {
+  width: 100%;
+  height: 34px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  padding: 0;
+}
+.image-editor-field input[type="range"] {
+  width: 100%;
+}
+.image-editor-field output {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+.image-editor-field--split {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.6rem;
+}
+.image-editor-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding: 0.85rem 1.25rem 1.1rem;
+  border-top: 1px solid var(--border-color);
+}
+.image-editor-footer button {
+  border: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  color: inherit;
+  padding: 0.45rem 0.9rem;
+  border-radius: 6px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.image-editor-footer .apply-btn {
+  background: var(--btn-primary-bg);
+  color: var(--btn-primary-text);
+  border-color: transparent;
+}
+.image-editor-footer .apply-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+@media (max-width: 900px) {
+  .image-editor-body {
+    flex-direction: column;
+    max-height: calc(90vh - 150px);
+  }
+  .image-editor-controls {
+    width: 100%;
+    max-height: 45vh;
+  }
+  .image-editor-preview {
+    width: 100%;
+  }
 }
 .section-nav-toggle {
     display: inline-flex;


### PR DESCRIPTION
## Summary
- add PNG and PDF export options to the table tools, including SVG-to-canvas rendering and PDF generation utilities
- introduce an image editor modal with crop and text overlay controls for inline images and hook it into the image toolbar
- extend styles to support the new table export buttons and the image editing workspace

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d96eacf998832c9880e831532c76a0