### PR TITLE
Fix HTML insertion and callout styling

### DIFF
--- a/index.css
+++ b/index.css
@@ -2095,6 +2095,11 @@ table.table-striped tr:first-child td {
 .note-mint-bottom { border:1px solid #c8e6c9; border-bottom-width:6px; background:#fbfffb; }
 .note-violet-shadow { border:1px solid #e6e0f8; background:#fdfcff; box-shadow:0 1px 3px rgba(0,0,0,.03); }
 .note-gray-neutral { border:1px solid #e0e0e0; background:#f9f9f9; }
+.note-info { background:#eaf6ff; border-color:#bcd8f3; border-left-color:#4a90e2; border-left-width:6px; min-height:40px; }
+.note-warning { background:#fff9eb; border-color:#f4e4b3; border-left-color:#e6b800; border-left-width:6px; min-height:40px; }
+.note-error { background:#fff1f0; border-color:#f3bcbc; border-left-color:#e05252; border-left-width:6px; min-height:40px; }
+.note-success { background:#f2fbf2; border-color:#c4e8d2; border-left-color:#2d9d5c; border-left-width:6px; min-height:40px; }
+.note-neutral { background:#f6f6f9; border-color:#d9d3ec; border-left-color:#9a7dca; border-left-width:6px; min-height:40px; }
 .note-shadow { box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
 .predef-note-btn { margin:0; cursor:pointer; }
 

--- a/index.html
+++ b/index.html
@@ -629,6 +629,11 @@
                     <button class="predef-note-btn note-callout note-mint-bottom" data-class="note-mint-bottom">🌿 Menta Inferior</button>
                     <button class="predef-note-btn note-callout note-violet-shadow" data-class="note-violet-shadow">🔎 Violeta Ultraligera</button>
                     <button class="predef-note-btn note-callout note-gray-neutral" data-class="note-gray-neutral">⚪ Nota Gris</button>
+                    <button class="predef-note-btn note-callout note-info" data-class="note-info">ℹ️ Nota Informativa</button>
+                    <button class="predef-note-btn note-callout note-warning" data-class="note-warning">⚠️ Nota de Advertencia</button>
+                    <button class="predef-note-btn note-callout note-error" data-class="note-error">⛔ Nota Crítica</button>
+                    <button class="predef-note-btn note-callout note-success" data-class="note-success">✅ Nota Positiva</button>
+                    <button class="predef-note-btn note-callout note-neutral" data-class="note-neutral">🗂️ Nota Neutral</button>
                 </div>
             </div>
             <div id="note-style-custom" class="hidden space-y-2">


### PR DESCRIPTION
## Summary
- restore HTML insertion to reuse the caret location and avoid losing content when inserting templates
- improve note callout selection handling so notes wrap the highlighted text and add five preset styles for quick insertion
- style the new callout presets with distinct colors for informational, warning, error, success, and neutral notes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da0d0e2198832c9eb453ddf8611ea8